### PR TITLE
chore(deps): bump com.azure:azure-sdk-bom from 1.2.27 to 1.2.28

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -61,7 +61,7 @@ dependencies {
     compileOnly'org.slf4j:slf4j-api'
 
     // azure
-    api platform("com.azure:azure-sdk-bom:1.2.27")
+    api platform("com.azure:azure-sdk-bom:1.2.28")
     api (group: 'com.azure', name: 'azure-identity') {
         // exclude libraries already provided by Kestra
         exclude group: 'com.fasterxml.jackson.core'


### PR DESCRIPTION
Dependabot updates : #144 