### PR TITLE
Fix/upload issue with azure storage

### DIFF
--- a/src/main/java/io/kestra/plugin/azure/storage/adls/Upload.java
+++ b/src/main/java/io/kestra/plugin/azure/storage/adls/Upload.java
@@ -1,7 +1,10 @@
 package io.kestra.plugin.azure.storage.adls;
 
 import com.azure.core.util.BinaryData;
+import com.azure.core.util.FluxUtil;
+import com.azure.storage.common.implementation.Constants;
 import com.azure.storage.file.datalake.DataLakeFileClient;
+import com.microsoft.azure.storage.blob.BlobInputStream;
 import io.kestra.core.models.annotations.Example;
 import io.kestra.core.models.annotations.Plugin;
 import io.kestra.core.models.annotations.PluginProperty;
@@ -12,11 +15,13 @@ import io.kestra.core.runners.RunContext;
 import io.kestra.plugin.azure.storage.adls.abstracts.AbstractDataLakeWithFile;
 import io.kestra.plugin.azure.storage.adls.models.AdlsFile;
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.ToString;
 import lombok.experimental.SuperBuilder;
+import reactor.core.scheduler.Schedulers;
 
 import java.io.InputStream;
 import java.net.URI;
@@ -59,6 +64,7 @@ public class Upload extends AbstractDataLakeWithFile implements RunnableTask<Upl
         title = "The file from the internal storage to upload to the Azure Data Lake Storage."
     )
     @PluginProperty(internalStorageURI = true)
+    @NotNull
     private Property<String> from;
 
 

--- a/src/main/java/io/kestra/plugin/azure/storage/blob/Upload.java
+++ b/src/main/java/io/kestra/plugin/azure/storage/blob/Upload.java
@@ -13,6 +13,7 @@ import io.kestra.plugin.azure.storage.blob.models.AccessTier;
 import io.kestra.plugin.azure.storage.blob.models.Blob;
 import io.kestra.plugin.azure.storage.blob.models.BlobImmutabilityPolicy;
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -85,6 +86,7 @@ public class Upload extends AbstractBlobStorageWithSasObject implements Runnable
         title = "The file from the internal storage to upload to the Azure Blob Storage."
     )
     @PluginProperty(internalStorageURI = true)
+    @NotNull
     private Property<String> from;
 
     @Schema(


### PR DESCRIPTION
```
id: partridge_817906
namespace: company.team

tasks:
  - id: hello
    type: io.kestra.plugin.scripts.shell.Commands
    outputFiles:
      - upload.txt
    commands:
      - truncate -s 20M upload.txt
  - id: upload
    type: io.kestra.plugin.azure.storage.adls.Upload
    filePath: "uploadTestAdlsBig.txt"
    fileSystem: storage
    endpoint: https://core.windows.net
    connectionString: "connectionString"
    from: "{{outputs.hello.outputFiles['upload.txt']}}"
afterExecution:
  - id: a
    type: io.kestra.plugin.core.storage.PurgeCurrentExecutionFiles
```

Without fix:
![image](https://github.com/user-attachments/assets/582be883-39d4-4f4a-b432-72fbc8a2028e)

With fix:
![image](https://github.com/user-attachments/assets/63dbe541-0646-4653-ae86-acdc2644a888)

