### PR TITLE
Feat/add metric annotations for Azure Plugin

### DIFF
--- a/src/main/java/io/kestra/plugin/azure/batch/job/Create.java
+++ b/src/main/java/io/kestra/plugin/azure/batch/job/Create.java
@@ -122,13 +122,13 @@ import static io.kestra.core.utils.Rethrow.throwRunnable;
         )
     },
     metrics = {
-        @Metric(name = "io.read.ops.count", type = Counter.class.getName(), description = "The number of read I/O operations performed by the task."),
-        @Metric(name = "io.read.gib.count", type = Counter.class.getName(), description = "The number of gibibytes read from I/O by the task."),
-        @Metric(name = "io.write.ops.count", type = Counter.class.getName(), description = "The number of write I/O operations performed by the task."),
-        @Metric(name = "io.write.gib.count", type = Counter.class.getName(), description = "The number of gibibytes written to I/O by the task."),
-        @Metric(name = "cpu.kernel.duration", type = Timer.class.getName(), description = "The CPU kernel time."),
-        @Metric(name = "cpu.user.duration", type = Timer.class.getName(), description = "The CPU user time."),
-        @Metric(name = "wall.clock.duration", type = Timer.class.getName(), description = "The wall clock time.")
+        @Metric(name = "io.read.ops.count", type = Counter.TYPE, description = "The number of read I/O operations performed by the task."),
+        @Metric(name = "io.read.gib.count", type = Counter.TYPE, description = "The number of gibibytes read from I/O by the task."),
+        @Metric(name = "io.write.ops.count", type = Counter.TYPE , description = "The number of write I/O operations performed by the task."),
+        @Metric(name = "io.write.gib.count", type = Counter.TYPE, description = "The number of gibibytes written to I/O by the task."),
+        @Metric(name = "cpu.kernel.duration", type = Counter.TYPE, description = "The CPU kernel time."),
+        @Metric(name = "cpu.user.duration", type = Counter.TYPE, description = "The CPU user time."),
+        @Metric(name = "wall.clock.duration", type = Counter.TYPE, description = "The wall clock time.")
     }
 )
 @Schema(

--- a/src/main/java/io/kestra/plugin/azure/datafactory/CreateRun.java
+++ b/src/main/java/io/kestra/plugin/azure/datafactory/CreateRun.java
@@ -78,8 +78,8 @@ import java.util.concurrent.atomic.AtomicReference;
         )
     },
     metrics = {
-        @Metric(name = "pipeline.duration.ms", type = Timer.class.getName(), description = "The duration of the pipeline run in milliseconds."),
-        @Metric(name = "activities.count", type = Counter.class.getName(), description = "The total number of activities in the pipeline run.")
+        @Metric(name = "pipeline.duration.ms", type = Timer.TYPE, description = "The duration of the pipeline run in milliseconds."),
+        @Metric(name = "activities.count", type = Counter.TYPE, description = "The total number of activities in the pipeline run.")
     }
 )
 @Schema(

--- a/src/main/java/io/kestra/plugin/azure/eventhubs/Consume.java
+++ b/src/main/java/io/kestra/plugin/azure/eventhubs/Consume.java
@@ -48,6 +48,7 @@ import java.util.concurrent.atomic.AtomicReference;
 /**
  * The {@link RunnableTask} can be used for consuming batches of events from Azure Event Hubs.
  */
+
 @Plugin(
     examples = {
         @Example(
@@ -72,7 +73,7 @@ import java.util.concurrent.atomic.AtomicReference;
         )
     },
     metrics = {
-        @Metric(name = "records.consumed", type = Counter.class.getName(), description = "The total number of events consumed.")
+        @Metric(name = "records.consumed", type = Counter.TYPE, description = "The total number of events consumed.")
     }
 )
 @Schema(

--- a/src/main/java/io/kestra/plugin/azure/eventhubs/Produce.java
+++ b/src/main/java/io/kestra/plugin/azure/eventhubs/Produce.java
@@ -4,7 +4,7 @@ import com.azure.messaging.eventhubs.models.CreateBatchOptions;
 import io.kestra.core.exceptions.IllegalVariableEvaluationException;
 import io.kestra.core.models.annotations.Example;
 import io.kestra.core.models.annotations.Plugin;
-import io.kestra.core.models.annotaions.Metric;
+import io.kestra.core.models.annotations.Metric;
 import io.kestra.core.models.annotations.PluginProperty;
 import io.kestra.core.models.executions.metrics.Counter;
 import io.kestra.core.models.property.Property;
@@ -86,8 +86,8 @@ import java.util.Map;
         )
     },
     metrics = {
-        @Metric(name = "events.sent.count", type = Counter.class.getName(), description = "The total number of events sent."),
-        @Metric(name = "batches.sent.count", type = Counter.class.getName(), description = "The total number of batches sent.")
+        @Metric(name = "events.sent.count", type = Counter.TYPE, description = "The total number of events sent."),
+        @Metric(name = "batches.sent.count", type = Counter.TYPE, description = "The total number of batches sent.")
     }
 )
 @Schema(

--- a/src/main/java/io/kestra/plugin/azure/storage/adls/DeleteFiles.java
+++ b/src/main/java/io/kestra/plugin/azure/storage/adls/DeleteFiles.java
@@ -78,8 +78,8 @@ import static io.kestra.core.utils.Rethrow.throwConsumer;
         )
     },
     metrics = {
-        @Metric(name = "files.count", type = Counter.class.getName(), description = "The total number of files deleted."),
-        @Metric(name = "files.size", type = Counter.class.getName(), description = "The total size of all files deleted, in bytes.")
+        @Metric(name = "files.count", type = Counter.TYPE, description = "The total number of files deleted."),
+        @Metric(name = "files.size", type = Counter.TYPE, description = "The total size of all files deleted, in bytes.")
     }
 )
 @Schema(

--- a/src/main/java/io/kestra/plugin/azure/storage/adls/Upload.java
+++ b/src/main/java/io/kestra/plugin/azure/storage/adls/Upload.java
@@ -62,7 +62,7 @@ import java.net.URI;
         )
     },
     metrics = {
-        @Metric(name = "file.size", type = Counter.class.getName(), description = "The size of the uploaded file, in bytes.")
+        @Metric(name = "file.size", type = Counter.TYPE, description = "The size of the uploaded file, in bytes.")
     }
 )
 @Schema(

--- a/src/main/java/io/kestra/plugin/azure/storage/adls/update/Append.java
+++ b/src/main/java/io/kestra/plugin/azure/storage/adls/update/Append.java
@@ -44,8 +44,8 @@ import lombok.experimental.SuperBuilder;
         )
     },
     metrics = {
-        @Metric(name = "file.size", type = Counter.class.getName(), description = "The size of the file before appending data, in bytes."),
-        @Metric(name = "data.size", type = Counter.class.getName(), description = "The size of the appended data, in bytes.")
+        @Metric(name = "file.size", type = Counter.TYPE, description = "The size of the file before appending data, in bytes."),
+        @Metric(name = "data.size", type = Counter.TYPE, description = "The size of the appended data, in bytes.")
     }
 )
 @Schema(

--- a/src/main/java/io/kestra/plugin/azure/storage/blob/DeleteList.java
+++ b/src/main/java/io/kestra/plugin/azure/storage/blob/DeleteList.java
@@ -57,8 +57,8 @@ import static io.kestra.core.utils.Rethrow.throwConsumer;
         )
     },
     metrics = {
-        @Metric(name = "blobs.count", type = Counter.class.getName(), description = "The total number of blobs deleted."),
-        @Metric(name = "blobs.size", type = Counter.class.getName(), description = "The total size of all blobs deleted, in bytes.")
+        @Metric(name = "blobs.count", type = Counter.TYPE , description = "The total number of blobs deleted."),
+        @Metric(name = "blobs.size", type = Counter.TYPE, description = "The total size of all blobs deleted, in bytes.")
     }
 )
 @Schema(

--- a/src/main/java/io/kestra/plugin/azure/storage/blob/List.java
+++ b/src/main/java/io/kestra/plugin/azure/storage/blob/List.java
@@ -43,7 +43,7 @@ import lombok.experimental.SuperBuilder;
         )
     },
     metrics = {
-        @Metric(name = "blobs.count", type = Counter.class.getName(), description = "The total number of blobs listed.")
+        @Metric(name = "blobs.count", type = Counter.TYPE, description = "The total number of blobs listed.")
     }
 )
 @Schema(

--- a/src/main/java/io/kestra/plugin/azure/storage/blob/Upload.java
+++ b/src/main/java/io/kestra/plugin/azure/storage/blob/Upload.java
@@ -79,7 +79,7 @@ import static io.kestra.core.utils.Rethrow.throwFunction;
         )
     },
     metrics = {
-        @Metric(name = "file.size", type = Counter.class.getName(), description = "The size of the uploaded blob, in bytes.")
+        @Metric(name = "file.size", type = Counter.TYPE, description = "The size of the uploaded blob, in bytes.")
     }
 )
 @Schema(

--- a/src/main/java/io/kestra/plugin/azure/storage/table/Bulk.java
+++ b/src/main/java/io/kestra/plugin/azure/storage/table/Bulk.java
@@ -59,7 +59,7 @@ import static io.kestra.core.utils.Rethrow.throwFunction;
         )
     },
     metrics = {
-        @Metric(name = "records.count", type = Counter.class.getName(), description = "The total number of entities processed in the bulk operation.")
+        @Metric(name = "records.count", type = Counter.TYPE, description = "The total number of entities processed in the bulk operation.")
     }
 )
 @Schema(

--- a/src/main/java/io/kestra/plugin/azure/storage/table/List.java
+++ b/src/main/java/io/kestra/plugin/azure/storage/table/List.java
@@ -48,7 +48,7 @@ import java.net.URI;
         )
     },
     metrics = {
-        @Metric(name = "records.count", type = Counter.class.getName(), description = "The total number of entities listed.")
+        @Metric(name = "records.count", type = Counter.TYPE, description = "The total number of entities listed.")
     }
 )
 @Schema(


### PR DESCRIPTION
Closes https://github.com/kestra-io/kestra/issues/11931.

This PR adds the missing `@Metric` annotations to all required files in the `plugin-azure`.

This resolves the tasks for this plugin as described in the parent issue kestra-io/kestra#11901 and its sub-issue kestra-io/kestra#11931.

All metric names have been standardized to `dot.case` for consistency, and the annotation syntax has been corrected to use string literals for the `type` attribute. The code has been successfully built locally.