### PR TITLE
refactor(HttpFunction): simplify HTTP client implementation and improve error handling

### DIFF
--- a/src/main/java/io/kestra/plugin/azure/function/HttpFunction.java
+++ b/src/main/java/io/kestra/plugin/azure/function/HttpFunction.java
@@ -76,9 +76,9 @@ public class HttpFunction extends Task implements RunnableTask<HttpFunction.Outp
 
     @Override
     public HttpFunction.Output run(RunContext runContext) throws Exception {
-        String renderedUrl = runContext.render(url).as(String.class).orElseThrow();
-        String renderedMethod = runContext.render(httpMethod).as(String.class).orElseThrow();
-        Map<String, Object> renderedBody = runContext.render(httpBody).asMap(String.class, Object.class);
+        String rUrl = runContext.render(url).as(String.class).orElseThrow();
+        String rMethod = runContext.render(httpMethod).as(String.class).orElseThrow();
+        Map<String, Object> rBody = runContext.render(httpBody).asMap(String.class, Object.class);
         Duration timeout = runContext.render(maxDuration).as(Duration.class).orElseThrow();
 
         try (HttpClient client = HttpClient.builder()
@@ -89,12 +89,12 @@ public class HttpFunction extends Task implements RunnableTask<HttpFunction.Outp
                 .build()) {
 
             HttpRequest.HttpRequestBuilder requestBuilder = HttpRequest.builder()
-                .uri(URI.create(renderedUrl))
-                .method(renderedMethod);
+                .uri(URI.create(rUrl))
+                .method(rMethod);
 
-            if (renderedBody != null && !renderedBody.isEmpty()) {
+            if (rBody != null && !rBody.isEmpty()) {
                 requestBuilder.body(HttpRequest.JsonRequestBody.builder()
-                    .content(renderedBody)
+                    .content(rBody)
                     .build());
             }
 


### PR DESCRIPTION
fixes: https://github.com/kestra-io/plugin-azure/issues/219
--- 
Refactored [io.kestra.plugin.azure.function.HttpFunction](vscode-file://vscode-app/c:/Users/IRFAN/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) to use Kestra's abstracted HTTP client ([io.kestra.core.http.*](vscode-file://vscode-app/c:/Users/IRFAN/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html)) instead of direct Micronaut HTTP client dependencies

--- 
### changes:
**Imports**
- Added: [io.kestra.core.http.{HttpRequest, HttpResponse}](vscode-file://vscode-app/c:/Users/IRFAN/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html)
- Added: [io.kestra.core.http.client.{HttpClient, HttpClientException, HttpConfiguration}](vscode-file://vscode-app/c:/Users/IRFAN/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html)
- Removed: [io.micronaut.http.client.*](vscode-file://vscode-app/c:/Users/IRFAN/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) (Micronaut HTTP dependencies)
- Removed: [io.micronaut.http.client.netty.*](vscode-file://vscode-app/c:/Users/IRFAN/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) (Netty factory)
- Removed: reactor.core.publisher.Mono (reactive wrapper)

**Code Structure**
- Removed static NettyHttpClientFactory and HTTP_READ_TIMEOUT constants
- Removed custom [client()](vscode-file://vscode-app/c:/Users/IRFAN/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) method with manual Micronaut configuration
- Refactored [run()](vscode-file://vscode-app/c:/Users/IRFAN/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) method to use builder pattern with try-with-resources
- Simplified synchronous request execution (no reactive wrappers)
- Improved timeout handling - now uses user-configured [maxDuration](vscode-file://vscode-app/c:/Users/IRFAN/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) instead of hardcoded 60s


**Exception Handling**
- Removed: HttpClientResponseException (Micronaut-specific)
- Added: [HttpClientException](vscode-file://vscode-app/c:/Users/IRFAN/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) and [IOException](vscode-file://vscode-app/c:/Users/IRFAN/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) (Kestra standard)
- Wrapped exceptions in RuntimeException with descriptive messages
--- 