### PR TITLE
feat: add checksum validation

### DIFF
--- a/src/main/java/io/kestra/plugin/azure/storage/adls/Read.java
+++ b/src/main/java/io/kestra/plugin/azure/storage/adls/Read.java
@@ -6,7 +6,6 @@ import com.azure.storage.file.datalake.DataLakeFileClient;
 
 import io.kestra.core.models.annotations.Example;
 import io.kestra.core.models.annotations.Plugin;
-import io.kestra.core.models.annotations.PluginProperty;
 import io.kestra.core.models.property.Property;
 import io.kestra.core.models.tasks.RunnableTask;
 import io.kestra.core.runners.RunContext;
@@ -56,16 +55,12 @@ import lombok.experimental.SuperBuilder;
     title = "Read a file from Azure Data Lake Storage."
 )
 public class Read extends AbstractDataLakeWithFile implements RunnableTask<Read.Output>, SingleFileChecksumValidatedInterface {
-    @PluginProperty(group = "advanced")
     private Property<Boolean> validateChecksum;
 
-    @PluginProperty(group = "advanced")
     private Property<Boolean> failOnMissingChecksum;
 
-    @PluginProperty(group = "advanced")
     private Property<String> expectedChecksum;
 
-    @PluginProperty(group = "advanced")
     private Property<ChecksumValidator.Algorithm> checksumAlgorithm;
 
     @Override

--- a/src/main/java/io/kestra/plugin/azure/storage/adls/Read.java
+++ b/src/main/java/io/kestra/plugin/azure/storage/adls/Read.java
@@ -6,11 +6,15 @@ import com.azure.storage.file.datalake.DataLakeFileClient;
 
 import io.kestra.core.models.annotations.Example;
 import io.kestra.core.models.annotations.Plugin;
+import io.kestra.core.models.annotations.PluginProperty;
+import io.kestra.core.models.property.Property;
 import io.kestra.core.models.tasks.RunnableTask;
 import io.kestra.core.runners.RunContext;
 import io.kestra.plugin.azure.storage.adls.abstracts.AbstractDataLakeWithFile;
 import io.kestra.plugin.azure.storage.adls.models.AdlsFile;
 import io.kestra.plugin.azure.storage.adls.services.DataLakeService;
+import io.kestra.plugin.azure.storage.services.ChecksumValidator;
+import io.kestra.plugin.azure.storage.services.SingleFileChecksumValidatedInterface;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.EqualsAndHashCode;
@@ -51,11 +55,26 @@ import lombok.experimental.SuperBuilder;
 @Schema(
     title = "Read a file from Azure Data Lake Storage."
 )
-public class Read extends AbstractDataLakeWithFile implements RunnableTask<Read.Output> {
+public class Read extends AbstractDataLakeWithFile implements RunnableTask<Read.Output>, SingleFileChecksumValidatedInterface {
+    @PluginProperty(group = "advanced")
+    private Property<Boolean> validateChecksum;
+
+    @PluginProperty(group = "advanced")
+    private Property<Boolean> failOnMissingChecksum;
+
+    @PluginProperty(group = "advanced")
+    private Property<String> expectedChecksum;
+
+    @PluginProperty(group = "advanced")
+    private Property<ChecksumValidator.Algorithm> checksumAlgorithm;
+
     @Override
     public Output run(RunContext runContext) throws Exception {
         DataLakeFileClient client = this.dataLakeFileClient(runContext);
-        URI readFileUri = DataLakeService.read(runContext, client);
+        ChecksumValidator.Options checksumOptions = ChecksumValidator.resolve(
+            runContext, validateChecksum, failOnMissingChecksum, expectedChecksum, checksumAlgorithm
+        );
+        URI readFileUri = DataLakeService.read(runContext, client, checksumOptions);
 
         return Output
             .builder()

--- a/src/main/java/io/kestra/plugin/azure/storage/adls/Reads.java
+++ b/src/main/java/io/kestra/plugin/azure/storage/adls/Reads.java
@@ -18,6 +18,8 @@ import io.kestra.plugin.azure.storage.adls.abstracts.AbstractDataLakeConnection;
 import io.kestra.plugin.azure.storage.adls.abstracts.AbstractDataLakeStorageInterface;
 import io.kestra.plugin.azure.storage.adls.models.AdlsFile;
 import io.kestra.plugin.azure.storage.adls.services.DataLakeService;
+import io.kestra.plugin.azure.storage.services.ChecksumValidatedInterface;
+import io.kestra.plugin.azure.storage.services.ChecksumValidator;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
@@ -54,7 +56,7 @@ import io.kestra.core.models.annotations.PluginProperty;
 @Schema(
     title = "Read all files from an Azure Data Lake Storage directory."
 )
-public class Reads extends AbstractDataLakeConnection implements RunnableTask<Reads.Output>, AbstractDataLakeStorageInterface {
+public class Reads extends AbstractDataLakeConnection implements RunnableTask<Reads.Output>, AbstractDataLakeStorageInterface, ChecksumValidatedInterface {
     @Schema(title = "Directory Name")
     @NotNull
     @PluginProperty(group = "main")
@@ -70,6 +72,12 @@ public class Reads extends AbstractDataLakeConnection implements RunnableTask<Re
     @Builder.Default
     @PluginProperty(group = "processing")
     private Property<Integer> maxFiles = Property.ofValue(25);
+
+    @PluginProperty(group = "advanced")
+    private Property<Boolean> validateChecksum;
+
+    @PluginProperty(group = "advanced")
+    private Property<Boolean> failOnMissingChecksum;
 
     @Override
     public Reads.Output run(RunContext runContext) throws Exception {
@@ -90,13 +98,17 @@ public class Reads extends AbstractDataLakeConnection implements RunnableTask<Re
         DataLakeServiceClient client = this.dataLakeServiceClient(runContext);
         DataLakeFileSystemClient fileSystemClient = client.getFileSystemClient(runContext.render(this.fileSystem).as(String.class).orElseThrow());
 
+        ChecksumValidator.Options checksumOptions = ChecksumValidator.resolve(
+            runContext, validateChecksum, failOnMissingChecksum, null, null
+        );
+
         java.util.List<AdlsFile> list = run
             .getFiles()
             .stream()
             .map(throwFunction(object ->
             {
                 DataLakeFileClient fileClient = fileSystemClient.getFileClient(object.getName());
-                URI readFileUri = DataLakeService.read(runContext, fileClient);
+                URI readFileUri = DataLakeService.read(runContext, fileClient, checksumOptions);
 
                 return AdlsFile.of(fileClient)
                     .withUri(readFileUri);

--- a/src/main/java/io/kestra/plugin/azure/storage/adls/Reads.java
+++ b/src/main/java/io/kestra/plugin/azure/storage/adls/Reads.java
@@ -73,10 +73,8 @@ public class Reads extends AbstractDataLakeConnection implements RunnableTask<Re
     @PluginProperty(group = "processing")
     private Property<Integer> maxFiles = Property.ofValue(25);
 
-    @PluginProperty(group = "advanced")
     private Property<Boolean> validateChecksum;
 
-    @PluginProperty(group = "advanced")
     private Property<Boolean> failOnMissingChecksum;
 
     @Override

--- a/src/main/java/io/kestra/plugin/azure/storage/adls/services/DataLakeService.java
+++ b/src/main/java/io/kestra/plugin/azure/storage/adls/services/DataLakeService.java
@@ -23,13 +23,30 @@ import io.kestra.core.models.executions.metrics.Counter;
 import io.kestra.core.runners.RunContext;
 import io.kestra.core.utils.FileUtils;
 import io.kestra.plugin.azure.storage.adls.models.AdlsFile;
+import io.kestra.plugin.azure.storage.services.ChecksumValidator;
 
 public class DataLakeService {
     public static URI read(RunContext runContext, DataLakeFileClient client) throws IOException {
+        return read(runContext, client, null);
+    }
+
+    public static URI read(
+        RunContext runContext,
+        DataLakeFileClient client,
+        ChecksumValidator.Options checksumOptions
+    ) throws IOException {
         File tempFile = runContext.workingDir().createTempFile(FileUtils.getExtension(client.getFileName())).toFile();
         PathProperties pathProperties = client.readToFile(tempFile.getAbsolutePath(), true);
 
         runContext.metric(Counter.of("file.size", pathProperties.getFileSize()));
+
+        ChecksumValidator.verify(
+            runContext,
+            tempFile,
+            pathProperties.getContentMd5(),
+            checksumOptions,
+            client.getFilePath()
+        );
 
         return runContext.storage().putFile(tempFile);
     }

--- a/src/main/java/io/kestra/plugin/azure/storage/blob/Download.java
+++ b/src/main/java/io/kestra/plugin/azure/storage/blob/Download.java
@@ -9,7 +9,6 @@ import com.azure.storage.blob.models.BlobProperties;
 
 import io.kestra.core.models.annotations.Example;
 import io.kestra.core.models.annotations.Plugin;
-import io.kestra.core.models.annotations.PluginProperty;
 import io.kestra.core.models.property.Property;
 import io.kestra.core.models.tasks.RunnableTask;
 import io.kestra.core.runners.RunContext;
@@ -73,16 +72,12 @@ import lombok.experimental.SuperBuilder;
     description = "Fetches a blob and stores it in internal storage, returning metadata and the downloaded URI."
 )
 public class Download extends AbstractBlobStorageWithSasObject implements RunnableTask<Download.Output>, SingleFileChecksumValidatedInterface {
-    @PluginProperty(group = "advanced")
     private Property<Boolean> validateChecksum;
 
-    @PluginProperty(group = "advanced")
     private Property<Boolean> failOnMissingChecksum;
 
-    @PluginProperty(group = "advanced")
     private Property<String> expectedChecksum;
 
-    @PluginProperty(group = "advanced")
     private Property<ChecksumValidator.Algorithm> checksumAlgorithm;
 
     @Override

--- a/src/main/java/io/kestra/plugin/azure/storage/blob/Download.java
+++ b/src/main/java/io/kestra/plugin/azure/storage/blob/Download.java
@@ -9,11 +9,15 @@ import com.azure.storage.blob.models.BlobProperties;
 
 import io.kestra.core.models.annotations.Example;
 import io.kestra.core.models.annotations.Plugin;
+import io.kestra.core.models.annotations.PluginProperty;
+import io.kestra.core.models.property.Property;
 import io.kestra.core.models.tasks.RunnableTask;
 import io.kestra.core.runners.RunContext;
 import io.kestra.plugin.azure.shared.storage.blob.abstracts.AbstractBlobStorageWithSasObject;
 import io.kestra.plugin.azure.shared.storage.blob.models.Blob;
 import io.kestra.plugin.azure.storage.blob.services.BlobService;
+import io.kestra.plugin.azure.storage.services.ChecksumValidator;
+import io.kestra.plugin.azure.storage.services.SingleFileChecksumValidatedInterface;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.EqualsAndHashCode;
@@ -43,6 +47,24 @@ import lombok.experimental.SuperBuilder;
                     container: "mydata"
                     name: "myblob"
                 """
+        ),
+        @Example(
+            title = "Download with MD5 verification against the server's Content-MD5",
+            full = true,
+            code = """
+                id: azure_storage_blob_download_verified
+                namespace: company.team
+
+                tasks:
+                  - id: download
+                    type: io.kestra.plugin.azure.storage.blob.Download
+                    endpoint: "https://yourblob.blob.core.windows.net"
+                    connectionString: "DefaultEndpointsProtocol=...=="
+                    container: "mydata"
+                    name: "myblob"
+                    validateChecksum: true
+                    failOnMissingChecksum: true
+                """
         )
     }
 )
@@ -50,11 +72,26 @@ import lombok.experimental.SuperBuilder;
     title = "Download a blob to Kestra storage",
     description = "Fetches a blob and stores it in internal storage, returning metadata and the downloaded URI."
 )
-public class Download extends AbstractBlobStorageWithSasObject implements RunnableTask<Download.Output> {
+public class Download extends AbstractBlobStorageWithSasObject implements RunnableTask<Download.Output>, SingleFileChecksumValidatedInterface {
+    @PluginProperty(group = "advanced")
+    private Property<Boolean> validateChecksum;
+
+    @PluginProperty(group = "advanced")
+    private Property<Boolean> failOnMissingChecksum;
+
+    @PluginProperty(group = "advanced")
+    private Property<String> expectedChecksum;
+
+    @PluginProperty(group = "advanced")
+    private Property<ChecksumValidator.Algorithm> checksumAlgorithm;
+
     @Override
     public Output run(RunContext runContext) throws Exception {
         BlobClient blobClient = this.blobClient(runContext);
-        Pair<BlobProperties, URI> download = BlobService.download(runContext, blobClient);
+        ChecksumValidator.Options checksumOptions = ChecksumValidator.resolve(
+            runContext, validateChecksum, failOnMissingChecksum, expectedChecksum, checksumAlgorithm
+        );
+        Pair<BlobProperties, URI> download = BlobService.download(runContext, blobClient, checksumOptions);
 
         return Output
             .builder()

--- a/src/main/java/io/kestra/plugin/azure/storage/blob/Downloads.java
+++ b/src/main/java/io/kestra/plugin/azure/storage/blob/Downloads.java
@@ -23,6 +23,8 @@ import io.kestra.plugin.azure.storage.blob.abstracts.ActionInterface;
 import io.kestra.plugin.azure.shared.storage.blob.abstracts.ListInterface;
 import io.kestra.plugin.azure.shared.storage.blob.models.Blob;
 import io.kestra.plugin.azure.storage.blob.services.BlobService;
+import io.kestra.plugin.azure.storage.services.ChecksumValidatedInterface;
+import io.kestra.plugin.azure.storage.services.ChecksumValidator;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.*;
@@ -60,7 +62,7 @@ import io.kestra.core.models.annotations.PluginProperty;
     title = "Download multiple blobs to Kestra storage",
     description = "Lists blobs with optional prefix/regex, downloads them to internal storage, and optionally archives or moves according to action."
 )
-public class Downloads extends AbstractBlobStorageWithSas implements RunnableTask<Downloads.Output>, ListInterface, ActionInterface, AbstractBlobStorageContainerInterface {
+public class Downloads extends AbstractBlobStorageWithSas implements RunnableTask<Downloads.Output>, ListInterface, ActionInterface, AbstractBlobStorageContainerInterface, ChecksumValidatedInterface {
     @Schema(title = "Container", description = "Target container to list and download from")
     @PluginProperty(group = "main")
     private Property<String> container;
@@ -96,6 +98,12 @@ public class Downloads extends AbstractBlobStorageWithSas implements RunnableTas
     @PluginProperty(group = "processing")
     private Property<Integer> maxFiles = Property.ofValue(25);
 
+    @PluginProperty(group = "advanced")
+    private Property<Boolean> validateChecksum;
+
+    @PluginProperty(group = "advanced")
+    private Property<Boolean> failOnMissingChecksum;
+
     @Override
     public Output run(RunContext runContext) throws Exception {
         List task = List.builder()
@@ -118,6 +126,10 @@ public class Downloads extends AbstractBlobStorageWithSas implements RunnableTas
         BlobServiceClient client = this.client(runContext);
         BlobContainerClient containerClient = client.getBlobContainerClient(runContext.render(this.container).as(String.class).orElse(null));
 
+        ChecksumValidator.Options checksumOptions = ChecksumValidator.resolve(
+            runContext, validateChecksum, failOnMissingChecksum, null, null
+        );
+
         java.util.List<Blob> list = run
             .getBlobs()
             .stream()
@@ -125,7 +137,7 @@ public class Downloads extends AbstractBlobStorageWithSas implements RunnableTas
             {
                 BlobClient blobClient = containerClient.getBlobClient(object.getName());
 
-                Pair<BlobProperties, URI> download = BlobService.download(runContext, blobClient);
+                Pair<BlobProperties, URI> download = BlobService.download(runContext, blobClient, checksumOptions);
 
                 return Blob.of(blobClient, download.getLeft())
                     .withUri(download.getRight());

--- a/src/main/java/io/kestra/plugin/azure/storage/blob/Downloads.java
+++ b/src/main/java/io/kestra/plugin/azure/storage/blob/Downloads.java
@@ -98,10 +98,8 @@ public class Downloads extends AbstractBlobStorageWithSas implements RunnableTas
     @PluginProperty(group = "processing")
     private Property<Integer> maxFiles = Property.ofValue(25);
 
-    @PluginProperty(group = "advanced")
     private Property<Boolean> validateChecksum;
 
-    @PluginProperty(group = "advanced")
     private Property<Boolean> failOnMissingChecksum;
 
     @Override

--- a/src/main/java/io/kestra/plugin/azure/storage/blob/services/BlobService.java
+++ b/src/main/java/io/kestra/plugin/azure/storage/blob/services/BlobService.java
@@ -27,13 +27,30 @@ import io.kestra.plugin.azure.storage.blob.Copy;
 import io.kestra.plugin.azure.storage.blob.Delete;
 import io.kestra.plugin.azure.storage.blob.abstracts.ActionInterface;
 import io.kestra.plugin.azure.shared.storage.blob.models.Blob;
+import io.kestra.plugin.azure.storage.services.ChecksumValidator;
 
 public class BlobService {
     public static Pair<BlobProperties, URI> download(RunContext runContext, BlobClient client) throws IOException {
+        return download(runContext, client, null);
+    }
+
+    public static Pair<BlobProperties, URI> download(
+        RunContext runContext,
+        BlobClient client,
+        ChecksumValidator.Options checksumOptions
+    ) throws IOException {
         File tempFile = runContext.workingDir().createTempFile(FileUtils.getExtension(client.getBlobName())).toFile();
         BlobProperties blobProperties = client.downloadToFile(tempFile.getAbsolutePath(), true);
 
         runContext.metric(Counter.of("file.size", blobProperties.getBlobSize()));
+
+        ChecksumValidator.verify(
+            runContext,
+            tempFile,
+            blobProperties.getContentMd5(),
+            checksumOptions,
+            client.getBlobName()
+        );
 
         return Pair.of(blobProperties, runContext.storage().putFile(tempFile));
     }

--- a/src/main/java/io/kestra/plugin/azure/storage/services/ChecksumValidatedInterface.java
+++ b/src/main/java/io/kestra/plugin/azure/storage/services/ChecksumValidatedInterface.java
@@ -1,0 +1,27 @@
+package io.kestra.plugin.azure.storage.services;
+
+import io.kestra.core.models.annotations.PluginProperty;
+import io.kestra.core.models.property.Property;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+public interface ChecksumValidatedInterface {
+    @Schema(
+        title = "Validate checksum against server's Content-MD5",
+        description = """
+            If true, compute the MD5 of the downloaded file and compare it to the
+            Content-MD5 stored on the Azure object. Many block blobs uploaded as
+            streams have no Content-MD5; see failOnMissingChecksum to control that case."""
+    )
+    @PluginProperty(group = "advanced")
+    Property<Boolean> getValidateChecksum();
+
+    @Schema(
+        title = "Fail when the server has no Content-MD5",
+        description = """
+            Only applies when validateChecksum is true. If true, the task fails when
+            the Azure object has no stored Content-MD5. If false (default), validation
+            is skipped with a warning."""
+    )
+    @PluginProperty(group = "advanced")
+    Property<Boolean> getFailOnMissingChecksum();
+}

--- a/src/main/java/io/kestra/plugin/azure/storage/services/ChecksumValidatedInterface.java
+++ b/src/main/java/io/kestra/plugin/azure/storage/services/ChecksumValidatedInterface.java
@@ -12,7 +12,7 @@ public interface ChecksumValidatedInterface {
             Content-MD5 stored on the Azure object. Many block blobs uploaded as
             streams have no Content-MD5; see failOnMissingChecksum to control that case."""
     )
-    @PluginProperty(group = "advanced")
+    @PluginProperty(group = "reliability")
     Property<Boolean> getValidateChecksum();
 
     @Schema(
@@ -22,6 +22,6 @@ public interface ChecksumValidatedInterface {
             the Azure object has no stored Content-MD5. If false (default), validation
             is skipped with a warning."""
     )
-    @PluginProperty(group = "advanced")
+    @PluginProperty(group = "reliability")
     Property<Boolean> getFailOnMissingChecksum();
 }

--- a/src/main/java/io/kestra/plugin/azure/storage/services/ChecksumValidator.java
+++ b/src/main/java/io/kestra/plugin/azure/storage/services/ChecksumValidator.java
@@ -56,16 +56,10 @@ public final class ChecksumValidator {
         Property<String> expectedChecksum,
         Property<Algorithm> checksumAlgorithm
     ) throws IllegalVariableEvaluationException {
-        boolean rValidate = validateChecksum != null
-            && runContext.render(validateChecksum).as(Boolean.class).orElse(false);
-        boolean rFailOnMissing = failOnMissingChecksum != null
-            && runContext.render(failOnMissingChecksum).as(Boolean.class).orElse(false);
-        String rExpected = expectedChecksum != null
-            ? runContext.render(expectedChecksum).as(String.class).orElse(null)
-            : null;
-        Algorithm rAlgorithm = checksumAlgorithm != null
-            ? runContext.render(checksumAlgorithm).as(Algorithm.class).orElse(Algorithm.MD5)
-            : Algorithm.MD5;
+        boolean rValidate = runContext.render(validateChecksum).as(Boolean.class).orElse(false);
+        boolean rFailOnMissing = runContext.render(failOnMissingChecksum).as(Boolean.class).orElse(false);
+        String rExpected = runContext.render(expectedChecksum).as(String.class).orElse(null);
+        Algorithm rAlgorithm = runContext.render(checksumAlgorithm).as(Algorithm.class).orElse(Algorithm.MD5);
 
         return Options.builder()
             .validateAgainstServer(rValidate)

--- a/src/main/java/io/kestra/plugin/azure/storage/services/ChecksumValidator.java
+++ b/src/main/java/io/kestra/plugin/azure/storage/services/ChecksumValidator.java
@@ -1,0 +1,186 @@
+package io.kestra.plugin.azure.storage.services;
+
+import io.kestra.core.exceptions.IllegalVariableEvaluationException;
+import io.kestra.core.models.executions.metrics.Counter;
+import io.kestra.core.models.property.Property;
+import io.kestra.core.runners.RunContext;
+import lombok.Builder;
+import lombok.Value;
+import org.slf4j.Logger;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.Base64;
+import java.util.HexFormat;
+
+public final class ChecksumValidator {
+    private ChecksumValidator() {
+    }
+
+    public enum Algorithm {
+        MD5("MD5"),
+        SHA_256("SHA-256");
+
+        private final String javaName;
+
+        Algorithm(String javaName) {
+            this.javaName = javaName;
+        }
+
+        public String javaName() {
+            return javaName;
+        }
+    }
+
+    @Value
+    @Builder
+    public static class Options {
+        boolean validateAgainstServer;
+        boolean failOnMissingServerChecksum;
+        String expected;
+        Algorithm algorithm;
+
+        public boolean enabled() {
+            return validateAgainstServer || expected != null;
+        }
+    }
+
+    public static Options resolve(
+        RunContext runContext,
+        Property<Boolean> validateChecksum,
+        Property<Boolean> failOnMissingChecksum,
+        Property<String> expectedChecksum,
+        Property<Algorithm> checksumAlgorithm
+    ) throws IllegalVariableEvaluationException {
+        boolean rValidate = validateChecksum != null
+            && runContext.render(validateChecksum).as(Boolean.class).orElse(false);
+        boolean rFailOnMissing = failOnMissingChecksum != null
+            && runContext.render(failOnMissingChecksum).as(Boolean.class).orElse(false);
+        String rExpected = expectedChecksum != null
+            ? runContext.render(expectedChecksum).as(String.class).orElse(null)
+            : null;
+        Algorithm rAlgorithm = checksumAlgorithm != null
+            ? runContext.render(checksumAlgorithm).as(Algorithm.class).orElse(Algorithm.MD5)
+            : Algorithm.MD5;
+
+        return Options.builder()
+            .validateAgainstServer(rValidate)
+            .failOnMissingServerChecksum(rFailOnMissing)
+            .expected(rExpected)
+            .algorithm(rAlgorithm)
+            .build();
+    }
+
+    /**
+     * Validates the local file's checksum against either a user-supplied expected value
+     * or the server-stored Content-MD5. User-supplied {@code expected} takes precedence.
+     *
+     * @param serverContentMd5 server-stored MD5 bytes, may be null
+     */
+    public static void verify(
+        RunContext runContext,
+        File file,
+        byte[] serverContentMd5,
+        Options options,
+        String resourceName
+    ) throws IOException {
+        if (options == null || !options.enabled()) {
+            return;
+        }
+
+        Logger logger = runContext.logger();
+        Algorithm algorithm = options.getAlgorithm() != null ? options.getAlgorithm() : Algorithm.MD5;
+
+        String expectedHex;
+        String comparisonSource;
+        if (options.getExpected() != null) {
+            expectedHex = normalizeExpected(options.getExpected(), algorithm);
+            comparisonSource = "expectedChecksum";
+        } else if (options.isValidateAgainstServer()) {
+            if (algorithm != Algorithm.MD5) {
+                throw new IllegalArgumentException(
+                    "validateChecksum against Azure only supports MD5; got " + algorithm
+                        + ". Provide expectedChecksum for " + algorithm + "."
+                );
+            }
+            if (serverContentMd5 == null || serverContentMd5.length == 0) {
+                String msg = "No Content-MD5 stored on server for '" + resourceName
+                    + "'. This is common for block blobs uploaded as streams.";
+                if (options.isFailOnMissingServerChecksum()) {
+                    runContext.metric(Counter.of("checksum.validated", 1, "result", "missing"));
+                    throw new IOException(msg);
+                }
+                logger.warn("{} Skipping checksum validation.", msg);
+                runContext.metric(Counter.of("checksum.validated", 1, "result", "skipped"));
+                return;
+            }
+            expectedHex = HexFormat.of().formatHex(serverContentMd5);
+            comparisonSource = "server Content-MD5";
+        } else {
+            return;
+        }
+
+        String actualHex = computeHex(file, algorithm);
+
+        if (!actualHex.equalsIgnoreCase(expectedHex)) {
+            runContext.metric(Counter.of("checksum.validated", 1, "result", "mismatch"));
+            throw new IOException(
+                "Checksum mismatch for '" + resourceName + "' using " + algorithm
+                    + " (source: " + comparisonSource + "). Expected=" + expectedHex
+                    + " actual=" + actualHex
+            );
+        }
+
+        runContext.metric(Counter.of("checksum.validated", 1, "result", "match"));
+        logger.debug("Checksum {} verified for '{}' (source: {})", algorithm, resourceName, comparisonSource);
+    }
+
+    private static String computeHex(File file, Algorithm algorithm) throws IOException {
+        MessageDigest digest;
+        try {
+            digest = MessageDigest.getInstance(algorithm.javaName());
+        } catch (NoSuchAlgorithmException e) {
+            throw new IOException("Algorithm " + algorithm + " not available", e);
+        }
+
+        try (InputStream in = new FileInputStream(file)) {
+            byte[] buffer = new byte[8192];
+            int read;
+            while ((read = in.read(buffer)) != -1) {
+                digest.update(buffer, 0, read);
+            }
+        }
+        return HexFormat.of().formatHex(digest.digest());
+    }
+
+    private static String normalizeExpected(String expected, Algorithm algorithm) {
+        String trimmed = expected.trim();
+        int expectedHexLength = expectedDigestBytes(algorithm) * 2;
+
+        if (trimmed.length() == expectedHexLength && trimmed.matches("[0-9a-fA-F]+")) {
+            return trimmed;
+        }
+        try {
+            byte[] decoded = Base64.getDecoder().decode(trimmed);
+            if (decoded.length == expectedDigestBytes(algorithm)) {
+                return HexFormat.of().formatHex(decoded);
+            }
+        } catch (IllegalArgumentException ignored) {
+        }
+        throw new IllegalArgumentException(
+            "expectedChecksum '" + expected + "' is not a valid " + algorithm
+                + " digest (expected " + expectedHexLength + " hex chars or matching base64)."
+        );
+    }
+
+    private static int expectedDigestBytes(Algorithm algorithm) {
+        return switch (algorithm) {
+            case MD5 -> 16;
+            case SHA_256 -> 32;
+        };
+    }
+}

--- a/src/main/java/io/kestra/plugin/azure/storage/services/SingleFileChecksumValidatedInterface.java
+++ b/src/main/java/io/kestra/plugin/azure/storage/services/SingleFileChecksumValidatedInterface.java
@@ -1,0 +1,27 @@
+package io.kestra.plugin.azure.storage.services;
+
+import io.kestra.core.models.annotations.PluginProperty;
+import io.kestra.core.models.property.Property;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+public interface SingleFileChecksumValidatedInterface extends ChecksumValidatedInterface {
+    @Schema(
+        title = "Expected checksum",
+        description = """
+            User-supplied expected checksum for the downloaded file. Accepts a lowercase
+            or uppercase hex digest, or the equivalent base64 encoding (Azure's native
+            Content-MD5 format). Takes precedence over validateChecksum."""
+    )
+    @PluginProperty(group = "advanced")
+    Property<String> getExpectedChecksum();
+
+    @Schema(
+        title = "Checksum algorithm",
+        description = """
+            Algorithm used to compute and compare the checksum. Defaults to MD5.
+            Note: validateChecksum (server-side) only supports MD5, since that is what
+            Azure stores. SHA-256 requires expectedChecksum."""
+    )
+    @PluginProperty(group = "advanced")
+    Property<ChecksumValidator.Algorithm> getChecksumAlgorithm();
+}

--- a/src/main/java/io/kestra/plugin/azure/storage/services/SingleFileChecksumValidatedInterface.java
+++ b/src/main/java/io/kestra/plugin/azure/storage/services/SingleFileChecksumValidatedInterface.java
@@ -12,7 +12,7 @@ public interface SingleFileChecksumValidatedInterface extends ChecksumValidatedI
             or uppercase hex digest, or the equivalent base64 encoding (Azure's native
             Content-MD5 format). Takes precedence over validateChecksum."""
     )
-    @PluginProperty(group = "advanced")
+    @PluginProperty(group = "reliability")
     Property<String> getExpectedChecksum();
 
     @Schema(
@@ -22,6 +22,6 @@ public interface SingleFileChecksumValidatedInterface extends ChecksumValidatedI
             Note: validateChecksum (server-side) only supports MD5, since that is what
             Azure stores. SHA-256 requires expectedChecksum."""
     )
-    @PluginProperty(group = "advanced")
+    @PluginProperty(group = "reliability")
     Property<ChecksumValidator.Algorithm> getChecksumAlgorithm();
 }

--- a/src/test/java/io/kestra/plugin/azure/storage/adls/ChecksumTest.java
+++ b/src/test/java/io/kestra/plugin/azure/storage/adls/ChecksumTest.java
@@ -1,0 +1,123 @@
+package io.kestra.plugin.azure.storage.adls;
+
+import io.kestra.core.models.property.Property;
+import io.kestra.core.utils.IdUtils;
+import io.kestra.plugin.azure.BaseTest;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.security.MessageDigest;
+import java.util.HexFormat;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class ChecksumTest extends AbstractTest {
+    private String md5OfApplicationYml() throws Exception {
+        byte[] content = Files.readAllBytes(BaseTest.file("application.yml").toPath());
+        byte[] digest = MessageDigest.getInstance("MD5").digest(content);
+        return HexFormat.of().formatHex(digest);
+    }
+
+    @Test
+    void readWithMatchingExpectedChecksumSucceeds() throws Exception {
+        String prefix = IdUtils.create();
+        Upload.Output upload = upload("adls/azure/" + prefix);
+
+        Read read = Read.builder()
+            .id(ChecksumTest.class.getSimpleName())
+            .type(Read.class.getName())
+            .endpoint(Property.ofValue(this.adlsEndpoint))
+            .connectionString(Property.ofValue(connectionString))
+            .fileSystem(Property.ofValue(this.fileSystem))
+            .filePath(Property.ofValue(upload.getFile().getName()))
+            .expectedChecksum(Property.ofValue(md5OfApplicationYml()))
+            .build();
+
+        Read.Output run = read.run(runContext(read));
+        assertThat(run.getFile().getUri(), is(notNullValue()));
+    }
+
+    @Test
+    void readWithMismatchedExpectedChecksumFails() throws Exception {
+        String prefix = IdUtils.create();
+        Upload.Output upload = upload("adls/azure/" + prefix);
+
+        Read read = Read.builder()
+            .id(ChecksumTest.class.getSimpleName())
+            .type(Read.class.getName())
+            .endpoint(Property.ofValue(this.adlsEndpoint))
+            .connectionString(Property.ofValue(connectionString))
+            .fileSystem(Property.ofValue(this.fileSystem))
+            .filePath(Property.ofValue(upload.getFile().getName()))
+            .expectedChecksum(Property.ofValue("00000000000000000000000000000000"))
+            .build();
+
+        IOException e = assertThrows(IOException.class,
+            () -> read.run(runContext(read)));
+        assertThat(e.getMessage(), containsString("Checksum mismatch"));
+    }
+
+    @Test
+    void readValidateAgainstServerSkipsWhenNoServerMd5() throws Exception {
+        String prefix = IdUtils.create();
+        Upload.Output upload = upload("adls/azure/" + prefix);
+
+        Read read = Read.builder()
+            .id(ChecksumTest.class.getSimpleName())
+            .type(Read.class.getName())
+            .endpoint(Property.ofValue(this.adlsEndpoint))
+            .connectionString(Property.ofValue(connectionString))
+            .fileSystem(Property.ofValue(this.fileSystem))
+            .filePath(Property.ofValue(upload.getFile().getName()))
+            .validateChecksum(Property.ofValue(true))
+            .build();
+
+        assertDoesNotThrow(() -> read.run(runContext(read)));
+    }
+
+    @Test
+    void readsValidateChecksumAcrossFiles() throws Exception {
+        String prefix = IdUtils.create();
+        upload("adls/azure/" + prefix);
+        upload("adls/azure/" + prefix);
+
+        Reads task = Reads.builder()
+            .id(ChecksumTest.class.getSimpleName())
+            .type(Reads.class.getName())
+            .endpoint(Property.ofValue(this.adlsEndpoint))
+            .connectionString(Property.ofValue(connectionString))
+            .fileSystem(Property.ofValue(this.fileSystem))
+            .directoryPath(Property.ofValue("adls/azure/" + prefix + "/"))
+            .validateChecksum(Property.ofValue(true))
+            .build();
+
+        Reads.Output run = task.run(runContext(task));
+        assertThat(run.getFiles().size(), is(2));
+        assertThat(run.getOutputFiles().size(), is(2));
+    }
+
+    @Test
+    void readsStrictMissingChecksumFails() throws Exception {
+        String prefix = IdUtils.create();
+        upload("adls/azure/" + prefix);
+
+        Reads task = Reads.builder()
+            .id(ChecksumTest.class.getSimpleName())
+            .type(Reads.class.getName())
+            .endpoint(Property.ofValue(this.adlsEndpoint))
+            .connectionString(Property.ofValue(connectionString))
+            .fileSystem(Property.ofValue(this.fileSystem))
+            .directoryPath(Property.ofValue("adls/azure/" + prefix + "/"))
+            .validateChecksum(Property.ofValue(true))
+            .failOnMissingChecksum(Property.ofValue(true))
+            .build();
+
+        assertThrows(IOException.class, () -> task.run(runContext(task)));
+    }
+}

--- a/src/test/java/io/kestra/plugin/azure/storage/blob/ChecksumTest.java
+++ b/src/test/java/io/kestra/plugin/azure/storage/blob/ChecksumTest.java
@@ -1,0 +1,149 @@
+package io.kestra.plugin.azure.storage.blob;
+
+import io.kestra.core.models.property.Property;
+import io.kestra.core.utils.IdUtils;
+import io.kestra.plugin.azure.BaseTest;
+import io.kestra.plugin.azure.storage.blob.abstracts.ActionInterface;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.security.MessageDigest;
+import java.util.HexFormat;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class ChecksumTest extends AbstractTest {
+    private String md5OfApplicationYml() throws Exception {
+        byte[] content = Files.readAllBytes(BaseTest.file("application.yml").toPath());
+        byte[] digest = MessageDigest.getInstance("MD5").digest(content);
+        return HexFormat.of().formatHex(digest);
+    }
+
+    @Test
+    void downloadWithMatchingExpectedChecksumSucceeds() throws Exception {
+        String prefix = IdUtils.create();
+        Upload.Output upload = upload("tasks/azure/" + prefix);
+
+        Download download = Download.builder()
+            .id(ChecksumTest.class.getSimpleName())
+            .type(Download.class.getName())
+            .endpoint(Property.ofValue(this.storageEndpoint))
+            .connectionString(Property.ofValue(connectionString))
+            .container(Property.ofValue(this.container))
+            .name(Property.ofValue(upload.getBlob().getName()))
+            .expectedChecksum(Property.ofValue(md5OfApplicationYml()))
+            .build();
+
+        Download.Output run = download.run(runContext(download));
+        assertThat(run.getBlob().getUri(), is(notNullValue()));
+    }
+
+    @Test
+    void downloadWithMismatchedExpectedChecksumFails() throws Exception {
+        String prefix = IdUtils.create();
+        Upload.Output upload = upload("tasks/azure/" + prefix);
+
+        Download download = Download.builder()
+            .id(ChecksumTest.class.getSimpleName())
+            .type(Download.class.getName())
+            .endpoint(Property.ofValue(this.storageEndpoint))
+            .connectionString(Property.ofValue(connectionString))
+            .container(Property.ofValue(this.container))
+            .name(Property.ofValue(upload.getBlob().getName()))
+            .expectedChecksum(Property.ofValue("00000000000000000000000000000000"))
+            .build();
+
+        IOException e = assertThrows(IOException.class,
+            () -> download.run(runContext(download)));
+        assertThat(e.getMessage(), containsString("Checksum mismatch"));
+    }
+
+    @Test
+    void downloadValidateAgainstServerSkipsWhenNoServerMd5() throws Exception {
+        String prefix = IdUtils.create();
+        Upload.Output upload = upload("tasks/azure/" + prefix);
+
+        // Upload.run streams the file via blobClient.upload(is, true) which does not
+        // set Content-MD5. We assert the lenient mode skips silently.
+        Download download = Download.builder()
+            .id(ChecksumTest.class.getSimpleName())
+            .type(Download.class.getName())
+            .endpoint(Property.ofValue(this.storageEndpoint))
+            .connectionString(Property.ofValue(connectionString))
+            .container(Property.ofValue(this.container))
+            .name(Property.ofValue(upload.getBlob().getName()))
+            .validateChecksum(Property.ofValue(true))
+            .build();
+
+        assertDoesNotThrow(() -> download.run(runContext(download)));
+    }
+
+    @Test
+    void downloadValidateAgainstServerStrictFailsWhenNoServerMd5() throws Exception {
+        String prefix = IdUtils.create();
+        Upload.Output upload = upload("tasks/azure/" + prefix);
+
+        Download download = Download.builder()
+            .id(ChecksumTest.class.getSimpleName())
+            .type(Download.class.getName())
+            .endpoint(Property.ofValue(this.storageEndpoint))
+            .connectionString(Property.ofValue(connectionString))
+            .container(Property.ofValue(this.container))
+            .name(Property.ofValue(upload.getBlob().getName()))
+            .validateChecksum(Property.ofValue(true))
+            .failOnMissingChecksum(Property.ofValue(true))
+            .build();
+
+        IOException e = assertThrows(IOException.class,
+            () -> download.run(runContext(download)));
+        assertThat(e.getMessage(), containsString("No Content-MD5"));
+    }
+
+    @Test
+    void downloadsValidateChecksumSkipsCleanlyAcrossFiles() throws Exception {
+        String prefix = IdUtils.create();
+        upload("tasks/azure/" + prefix);
+        upload("tasks/azure/" + prefix);
+
+        Downloads task = Downloads.builder()
+            .id(ChecksumTest.class.getSimpleName())
+            .type(Downloads.class.getName())
+            .endpoint(Property.ofValue(this.storageEndpoint))
+            .connectionString(Property.ofValue(connectionString))
+            .container(Property.ofValue(this.container))
+            .prefix(Property.ofValue("tasks/azure/" + prefix + "/"))
+            .action(Property.ofValue(ActionInterface.Action.NONE))
+            .validateChecksum(Property.ofValue(true))
+            .build();
+
+        Downloads.Output run = task.run(runContext(task));
+        assertThat(run.getBlobs().size(), is(2));
+        assertThat(run.getOutputFiles().size(), is(2));
+    }
+
+    @Test
+    void downloadsStrictMissingChecksumFails() throws Exception {
+        String prefix = IdUtils.create();
+        upload("tasks/azure/" + prefix);
+
+        Downloads task = Downloads.builder()
+            .id(ChecksumTest.class.getSimpleName())
+            .type(Downloads.class.getName())
+            .endpoint(Property.ofValue(this.storageEndpoint))
+            .connectionString(Property.ofValue(connectionString))
+            .container(Property.ofValue(this.container))
+            .prefix(Property.ofValue("tasks/azure/" + prefix + "/"))
+            .action(Property.ofValue(ActionInterface.Action.NONE))
+            .validateChecksum(Property.ofValue(true))
+            .failOnMissingChecksum(Property.ofValue(true))
+            .build();
+
+        assertThrows(IOException.class, () -> task.run(runContext(task)));
+    }
+}

--- a/src/test/java/io/kestra/plugin/azure/storage/services/ChecksumValidatorTest.java
+++ b/src/test/java/io/kestra/plugin/azure/storage/services/ChecksumValidatorTest.java
@@ -1,0 +1,178 @@
+package io.kestra.plugin.azure.storage.services;
+
+import io.kestra.core.junit.annotations.KestraTest;
+import io.kestra.core.runners.RunContext;
+import io.kestra.core.runners.RunContextFactory;
+import jakarta.inject.Inject;
+import org.junit.jupiter.api.Test;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.security.MessageDigest;
+import java.util.Base64;
+import java.util.Collections;
+import java.util.HexFormat;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+@KestraTest
+class ChecksumValidatorTest {
+    @Inject
+    private RunContextFactory runContextFactory;
+
+    private RunContext ctx() {
+        return runContextFactory.of(Collections.emptyMap());
+    }
+
+    private File writeTempFile(byte[] content) throws IOException {
+        Path tmp = Files.createTempFile("checksum-test-", ".bin");
+        Files.write(tmp, content);
+        return tmp.toFile();
+    }
+
+    private byte[] md5(byte[] content) throws Exception {
+        return MessageDigest.getInstance("MD5").digest(content);
+    }
+
+    @Test
+    void noOptionsIsNoOp() throws Exception {
+        File file = writeTempFile("hello".getBytes());
+        assertDoesNotThrow(() -> ChecksumValidator.verify(ctx(), file, null, null, "test"));
+    }
+
+    @Test
+    void disabledOptionsIsNoOp() throws Exception {
+        File file = writeTempFile("hello".getBytes());
+        ChecksumValidator.Options opts = ChecksumValidator.Options.builder()
+            .validateAgainstServer(false)
+            .algorithm(ChecksumValidator.Algorithm.MD5)
+            .build();
+        assertDoesNotThrow(() -> ChecksumValidator.verify(ctx(), file, new byte[]{1, 2, 3}, opts, "test"));
+    }
+
+    @Test
+    void serverMd5Match() throws Exception {
+        byte[] content = "hello world".getBytes();
+        File file = writeTempFile(content);
+        ChecksumValidator.Options opts = ChecksumValidator.Options.builder()
+            .validateAgainstServer(true)
+            .algorithm(ChecksumValidator.Algorithm.MD5)
+            .build();
+        ChecksumValidator.verify(ctx(), file, md5(content), opts, "test");
+    }
+
+    @Test
+    void serverMd5Mismatch() throws Exception {
+        byte[] content = "hello world".getBytes();
+        File file = writeTempFile(content);
+        byte[] wrong = md5("different".getBytes());
+        ChecksumValidator.Options opts = ChecksumValidator.Options.builder()
+            .validateAgainstServer(true)
+            .algorithm(ChecksumValidator.Algorithm.MD5)
+            .build();
+        IOException e = assertThrows(IOException.class,
+            () -> ChecksumValidator.verify(ctx(), file, wrong, opts, "test"));
+        assertThat(e.getMessage(), containsString("mismatch"));
+    }
+
+    @Test
+    void missingServerChecksumSkippedByDefault() throws Exception {
+        File file = writeTempFile("hello".getBytes());
+        ChecksumValidator.Options opts = ChecksumValidator.Options.builder()
+            .validateAgainstServer(true)
+            .failOnMissingServerChecksum(false)
+            .algorithm(ChecksumValidator.Algorithm.MD5)
+            .build();
+        assertDoesNotThrow(() -> ChecksumValidator.verify(ctx(), file, null, opts, "test"));
+    }
+
+    @Test
+    void missingServerChecksumFailsWhenStrict() throws Exception {
+        File file = writeTempFile("hello".getBytes());
+        ChecksumValidator.Options opts = ChecksumValidator.Options.builder()
+            .validateAgainstServer(true)
+            .failOnMissingServerChecksum(true)
+            .algorithm(ChecksumValidator.Algorithm.MD5)
+            .build();
+        IOException e = assertThrows(IOException.class,
+            () -> ChecksumValidator.verify(ctx(), file, null, opts, "myblob"));
+        assertThat(e.getMessage(), containsString("myblob"));
+    }
+
+    @Test
+    void expectedHexMatch() throws Exception {
+        byte[] content = "hello".getBytes();
+        File file = writeTempFile(content);
+        String hex = HexFormat.of().formatHex(md5(content));
+        ChecksumValidator.Options opts = ChecksumValidator.Options.builder()
+            .expected(hex)
+            .algorithm(ChecksumValidator.Algorithm.MD5)
+            .build();
+        ChecksumValidator.verify(ctx(), file, null, opts, "test");
+    }
+
+    @Test
+    void expectedBase64Match() throws Exception {
+        byte[] content = "hello".getBytes();
+        File file = writeTempFile(content);
+        String b64 = Base64.getEncoder().encodeToString(md5(content));
+        ChecksumValidator.Options opts = ChecksumValidator.Options.builder()
+            .expected(b64)
+            .algorithm(ChecksumValidator.Algorithm.MD5)
+            .build();
+        ChecksumValidator.verify(ctx(), file, null, opts, "test");
+    }
+
+    @Test
+    void expectedTakesPrecedenceOverServer() throws Exception {
+        byte[] content = "hello".getBytes();
+        File file = writeTempFile(content);
+        String hex = HexFormat.of().formatHex(md5(content));
+        // Server MD5 is wrong, but expected matches → no error
+        ChecksumValidator.Options opts = ChecksumValidator.Options.builder()
+            .validateAgainstServer(true)
+            .expected(hex)
+            .algorithm(ChecksumValidator.Algorithm.MD5)
+            .build();
+        ChecksumValidator.verify(ctx(), file, md5("nope".getBytes()), opts, "test");
+    }
+
+    @Test
+    void sha256ExpectedMatch() throws Exception {
+        byte[] content = "hello".getBytes();
+        File file = writeTempFile(content);
+        String hex = HexFormat.of().formatHex(MessageDigest.getInstance("SHA-256").digest(content));
+        ChecksumValidator.Options opts = ChecksumValidator.Options.builder()
+            .expected(hex)
+            .algorithm(ChecksumValidator.Algorithm.SHA_256)
+            .build();
+        ChecksumValidator.verify(ctx(), file, null, opts, "test");
+    }
+
+    @Test
+    void sha256AgainstServerIsRejected() throws Exception {
+        File file = writeTempFile("hello".getBytes());
+        ChecksumValidator.Options opts = ChecksumValidator.Options.builder()
+            .validateAgainstServer(true)
+            .algorithm(ChecksumValidator.Algorithm.SHA_256)
+            .build();
+        assertThrows(IllegalArgumentException.class,
+            () -> ChecksumValidator.verify(ctx(), file, new byte[]{1}, opts, "test"));
+    }
+
+    @Test
+    void malformedExpectedIsRejected() throws Exception {
+        File file = writeTempFile("hello".getBytes());
+        ChecksumValidator.Options opts = ChecksumValidator.Options.builder()
+            .expected("not-a-hash")
+            .algorithm(ChecksumValidator.Algorithm.MD5)
+            .build();
+        assertThrows(IllegalArgumentException.class,
+            () -> ChecksumValidator.verify(ctx(), file, null, opts, "test"));
+    }
+}


### PR DESCRIPTION
relates to https://github.com/kestra-io/kestra-ee/issues/5699

### QA

Flow used for QA : 

``` yaml
id: azure_storage_blob_download
namespace: company.team

tasks:
  - id: download
    type: io.kestra.plugin.azure.storage.blob.Download
    endpoint: "https://xx.blob.core.windows.net/storage/file.txt"
    connectionString: "DefaultEndpointsProtocol=https;AccountName=TRUNCATED"
    container: "storage"
    name: "file.txt"
    validateChecksum: true
    expectedChecksum: 1B2M2Y8AsgTpgAmY7PhCfg==
```

Some screenshot when checksum mismatch :

<img width="2329" height="384" alt="image" src="https://github.com/user-attachments/assets/f7487322-9317-490a-af24-380ba25e3546" />
