### PR TITLE
fix(plugin-azure-1): align @PluginSubGroup titles with metadata YAML

### DIFF
--- a/src/main/java/io/kestra/plugin/azure/auth/package-info.java
+++ b/src/main/java/io/kestra/plugin/azure/auth/package-info.java
@@ -1,5 +1,5 @@
 @PluginSubGroup(
-    title = "Authentication",
+    title = "Azure Authentication",
     description = "This sub-group of plugins contains tasks to manage authentication for Azure services.",
     categories = { PluginSubGroup.PluginCategory.CLOUD }
 )

--- a/src/main/java/io/kestra/plugin/azure/batch/job/package-info.java
+++ b/src/main/java/io/kestra/plugin/azure/batch/job/package-info.java
@@ -1,4 +1,5 @@
 @PluginSubGroup(
+    title = "Azure Batch Job",
     description = "This sub-group of plugins contains tasks for using Azure Batch Job.\n" +
         "Azure Batch runs large-scale applications efficiently in the cloud.",
     categories = { PluginSubGroup.PluginCategory.CLOUD, PluginSubGroup.PluginCategory.DATA, PluginSubGroup.PluginCategory.INFRASTRUCTURE }

--- a/src/main/java/io/kestra/plugin/azure/batch/pool/package-info.java
+++ b/src/main/java/io/kestra/plugin/azure/batch/pool/package-info.java
@@ -1,4 +1,5 @@
 @PluginSubGroup(
+    title = "Azure Batch Pool",
     description = "This sub-group of plugins contains tasks for using Azure Batch Pool.\n" +
         "Azure Batch runs large-scale applications efficiently in the cloud.",
     categories = { PluginSubGroup.PluginCategory.CLOUD, PluginSubGroup.PluginCategory.DATA, PluginSubGroup.PluginCategory.INFRASTRUCTURE }

--- a/src/main/java/io/kestra/plugin/azure/cli/package-info.java
+++ b/src/main/java/io/kestra/plugin/azure/cli/package-info.java
@@ -1,5 +1,5 @@
 @PluginSubGroup(
-    title = "CLI",
+    title = "Azure CLI",
     description = "This sub-group of plugins contains tasks to interact with Azure CLI. ",
     categories = { PluginSubGroup.PluginCategory.CLOUD, PluginSubGroup.PluginCategory.INFRASTRUCTURE }
 )

--- a/src/main/java/io/kestra/plugin/azure/datafactory/package-info.java
+++ b/src/main/java/io/kestra/plugin/azure/datafactory/package-info.java
@@ -1,4 +1,5 @@
 @PluginSubGroup(
+    title = "Azure Data Factory",
     description = "This sub-group of plugins contains tasks for using Azure Data Factory. \n" +
         "Azure Data Factory is a managed cloud service that's built for these complex hybrid extract-transform-load (ETL), extract-load-transform (ELT), and data integration projects.",
     categories = { PluginSubGroup.PluginCategory.CLOUD, PluginSubGroup.PluginCategory.DATA }

--- a/src/main/java/io/kestra/plugin/azure/eventhubs/package-info.java
+++ b/src/main/java/io/kestra/plugin/azure/eventhubs/package-info.java
@@ -1,4 +1,5 @@
 @PluginSubGroup(
+    title = "Azure Event Hubs",
     description = "This sub-group of plugins contains tasks for using Azure Event Hubs.",
     categories = { PluginSubGroup.PluginCategory.CLOUD, PluginSubGroup.PluginCategory.DATA }
 )

--- a/src/main/java/io/kestra/plugin/azure/function/package-info.java
+++ b/src/main/java/io/kestra/plugin/azure/function/package-info.java
@@ -1,4 +1,5 @@
 @PluginSubGroup(
+    title = "Azure Function",
     description = "This sub-group of plugins contains tasks for using Azure Functions. \n" +
         "Azure Functions is a serverless solution that allows you to write less code, maintain less infrastructure, and save on costs.",
     categories = { PluginSubGroup.PluginCategory.CLOUD }

--- a/src/main/java/io/kestra/plugin/azure/monitoring/package-info.java
+++ b/src/main/java/io/kestra/plugin/azure/monitoring/package-info.java
@@ -1,4 +1,5 @@
 @PluginSubGroup(
+    title = "Azure Monitoring",
     description = "This sub-group of plugins contains tasks for using Azure Monitor. \n" +
         "Azure Monitor provides full-stack observability across applications, infrastructure, and networks, " +
         "and enables querying and pushing metrics using Azure Monitor Query and Ingestion APIs.",

--- a/src/main/java/io/kestra/plugin/azure/servicebus/package-info.java
+++ b/src/main/java/io/kestra/plugin/azure/servicebus/package-info.java
@@ -1,4 +1,5 @@
 @PluginSubGroup(
+    title = "Azure Service Bus",
     description = "This sub-group of plugins contains tasks for using Azure Service Bus.\n" +
         "Azure Service Bus is a fully managed enterprise message broker with message queues and publish-subscribe topics.",
     categories = { PluginSubGroup.PluginCategory.CLOUD, PluginSubGroup.PluginCategory.DATA }

--- a/src/main/java/io/kestra/plugin/azure/storage/blob/package-info.java
+++ b/src/main/java/io/kestra/plugin/azure/storage/blob/package-info.java
@@ -1,4 +1,5 @@
 @PluginSubGroup(
+    title = "Azure Blob Storage",
     description = "This sub-group of plugins contains tasks for using Azure Blob Storage. \n" +
         "Azure Blob Storage includes object, file, disk, queue, and table storage.",
     categories = { PluginSubGroup.PluginCategory.CLOUD, PluginSubGroup.PluginCategory.DATA, PluginSubGroup.PluginCategory.INFRASTRUCTURE }

--- a/src/main/java/io/kestra/plugin/azure/storage/cosmosdb/package-info.java
+++ b/src/main/java/io/kestra/plugin/azure/storage/cosmosdb/package-info.java
@@ -1,4 +1,5 @@
 @PluginSubGroup(
+    title = "Cosmos DB",
     description = "This sub-group of plugins contains tasks for using Azure Cosmos DB.\n",
     categories = { PluginSubGroup.PluginCategory.DATA, PluginSubGroup.PluginCategory.CLOUD }
 )

--- a/src/main/java/io/kestra/plugin/azure/storage/table/package-info.java
+++ b/src/main/java/io/kestra/plugin/azure/storage/table/package-info.java
@@ -1,4 +1,5 @@
 @PluginSubGroup(
+    title = "Azure Table Storage",
     description = "This sub-group of plugins contains tasks for using Azure Table Storage.\n" +
         "Azure Storage includes object, file, disk, queue, and table storage.",
     categories = { PluginSubGroup.PluginCategory.CLOUD, PluginSubGroup.PluginCategory.DATA }

--- a/src/main/java/io/kestra/plugin/azure/streamanalytics/package-info.java
+++ b/src/main/java/io/kestra/plugin/azure/streamanalytics/package-info.java
@@ -1,4 +1,5 @@
 @PluginSubGroup(
+    title = "Azure Stream Analytics",
     description = "This sub-group of plugins contains tasks for using Azure Stream Analytics.\n" +
         "Azure Stream Analytics is a real-time analytics and complex event-processing engine.",
     categories = { PluginSubGroup.PluginCategory.CLOUD }

--- a/src/main/java/io/kestra/plugin/azure/synapse/package-info.java
+++ b/src/main/java/io/kestra/plugin/azure/synapse/package-info.java
@@ -1,4 +1,5 @@
 @PluginSubGroup(
+    title = "Azure Synapse",
     description = "Tasks for Azure Synapse Analytics.",
     categories = { PluginSubGroup.PluginCategory.CLOUD }
 )


### PR DESCRIPTION
## Summary

- Updates `@PluginSubGroup(title = ...)` in `package-info.java` files to match the `title` field in the corresponding subgroup metadata YAML files
- Eliminates duplicate/empty subgroup URLs on kestra.io caused by the annotation falling back to the package name when no title is set, while metadata uses a different slug

## Test plan

- [ ] Verify kestra.io subgroup pages no longer show empty duplicate routes after merge