### PR TITLE
feat: add checksum validation for upload

### DIFF
--- a/src/main/java/io/kestra/plugin/azure/storage/adls/Upload.java
+++ b/src/main/java/io/kestra/plugin/azure/storage/adls/Upload.java
@@ -2,17 +2,23 @@ package io.kestra.plugin.azure.storage.adls;
 
 import java.io.InputStream;
 import java.net.URI;
+import java.security.MessageDigest;
 
 import com.azure.core.util.BinaryData;
+import com.azure.core.util.Context;
 import com.azure.core.util.FluxUtil;
 import com.azure.storage.blob.BlobClient;
 import com.azure.storage.blob.BlobContainerClient;
 import com.azure.storage.blob.BlobServiceClient;
 import com.azure.storage.blob.BlobServiceClientBuilder;
+import com.azure.storage.blob.models.BlobRequestConditions;
+import com.azure.storage.blob.options.BlobParallelUploadOptions;
 import com.azure.storage.blob.specialized.BlobLeaseClient;
 import com.azure.storage.blob.specialized.BlobLeaseClientBuilder;
 import com.azure.storage.common.implementation.Constants;
 import com.azure.storage.file.datalake.DataLakeFileClient;
+import com.azure.storage.file.datalake.models.PathHttpHeaders;
+import com.azure.storage.file.datalake.options.FileParallelUploadOptions;
 
 import io.kestra.core.models.annotations.Example;
 import io.kestra.core.models.annotations.Metric;
@@ -89,6 +95,13 @@ public class Upload extends AbstractDataLakeWithFile implements RunnableTask<Upl
     @PluginProperty(group = "execution")
     private Property<Integer> leaseDurationSeconds;
 
+    @Schema(
+        title = "Validate checksum",
+        description = "Compute MD5 client-side and pass it to Azure for server-side integrity verification; on mismatch the upload fails with Md5Mismatch"
+    )
+    @PluginProperty(group = "reliability")
+    private Property<Boolean> validateChecksum;
+
     @Override
     public Upload.Output run(RunContext runContext) throws Exception {
         URI fromUri = new URI(runContext.render(this.from).as(String.class).orElseThrow());
@@ -97,6 +110,7 @@ public class Upload extends AbstractDataLakeWithFile implements RunnableTask<Upl
             DataLakeFileClient fileClient = this.dataLakeFileClient(runContext);
 
             boolean enableLease = runContext.render(this.useLease).as(Boolean.class).orElse(false);
+            boolean rValidateChecksum = runContext.render(this.validateChecksum).as(Boolean.class).orElse(false);
             int leaseDuration = Math.max(
                 AZURE_LEASE_MIN_DURATION,
                 Math.min(
@@ -141,11 +155,22 @@ public class Upload extends AbstractDataLakeWithFile implements RunnableTask<Upl
                         .subscribeOn(Schedulers.boundedElastic())
                 ).block();
 
-                if (enableLease && leaseId != null && blobClient != null && binaryData != null) {
-                    blobClient.upload(binaryData.toStream(), true);
+                if (enableLease && leaseId != null && binaryData != null) {
+                    blobClient.uploadWithResponse(
+                        new BlobParallelUploadOptions(binaryData)
+                            .setComputeMd5(rValidateChecksum)
+                            .setRequestConditions(new BlobRequestConditions().setLeaseId(leaseId)),
+                        null,
+                        Context.NONE
+                    );
                     runContext.logger().debug("Uploaded file {} using blobClient under lease {}", filePath, leaseId);
-                } else {
-                    fileClient.upload(binaryData, true);
+                } else if (binaryData != null) {
+                    FileParallelUploadOptions options = new FileParallelUploadOptions(binaryData);
+                    if (rValidateChecksum) {
+                        byte[] md5 = MessageDigest.getInstance("MD5").digest(binaryData.toBytes());
+                        options.setHeaders(new PathHttpHeaders().setContentMd5(md5));
+                    }
+                    fileClient.uploadWithResponse(options, null, Context.NONE);
                     runContext.logger().debug("Uploaded file {} using fileClient (no lease)", filePath);
                 }
 

--- a/src/main/java/io/kestra/plugin/azure/storage/blob/Upload.java
+++ b/src/main/java/io/kestra/plugin/azure/storage/blob/Upload.java
@@ -7,7 +7,9 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
+import com.azure.core.util.Context;
 import com.azure.storage.blob.BlobClient;
+import com.azure.storage.blob.options.BlobParallelUploadOptions;
 
 import io.kestra.core.models.annotations.Example;
 import io.kestra.core.models.annotations.Metric;
@@ -143,10 +145,18 @@ public class Upload extends AbstractBlobStorageWithSasObject implements Runnable
     @PluginProperty(group = "advanced")
     private BlobImmutabilityPolicy immutabilityPolicy;
 
+    @Schema(
+        title = "Validate checksum",
+        description = "Compute MD5 client-side and pass it to Azure for server-side integrity verification; on mismatch the upload fails with Md5Mismatch"
+    )
+    @PluginProperty(group = "reliability")
+    private Property<Boolean> validateChecksum;
+
     @Override
     public Upload.Output run(RunContext runContext) throws Exception {
         BlobClient baseClient = this.blobClient(runContext);
         List<Blob> uploadedBlobs = new ArrayList<>();
+        boolean rValidateChecksum = runContext.render(this.validateChecksum).as(Boolean.class).orElse(false);
 
         var rFrom = this.from;
         if (rFrom instanceof Property<?> propertyFrom) {
@@ -206,7 +216,11 @@ public class Upload extends AbstractBlobStorageWithSasObject implements Runnable
                 runContext.logger().debug("Upload from '{}' to '{}'", fileUri, blobClient.getBlobName());
 
                 try (var is = runContext.storage().getFile(fileUri)) {
-                    blobClient.upload(is, true);
+                    blobClient.uploadWithResponse(
+                        new BlobParallelUploadOptions(is).setComputeMd5(rValidateChecksum),
+                        null,
+                        Context.NONE
+                    );
                 }
 
                 if (this.metadata != null) {

--- a/src/test/java/io/kestra/plugin/azure/storage/adls/AbstractTest.java
+++ b/src/test/java/io/kestra/plugin/azure/storage/adls/AbstractTest.java
@@ -17,6 +17,10 @@ public class AbstractTest extends BaseTest {
     public java.util.List<String> directoryToClean = new ArrayList<>();
 
     protected Upload.Output upload(String dir) throws Exception {
+        return upload(dir, false);
+    }
+
+    protected Upload.Output upload(String dir, boolean validateChecksum) throws Exception {
         URI source = upload();
 
         String out = IdUtils.create();
@@ -29,6 +33,7 @@ public class AbstractTest extends BaseTest {
             .fileSystem(Property.ofValue(this.fileSystem))
             .from(Property.ofValue(source.toString()))
             .filePath(Property.ofValue(dir + "/" + out + ".yml"))
+            .validateChecksum(Property.ofValue(validateChecksum))
             .build();
 
         directoryToClean.add(dir);

--- a/src/test/java/io/kestra/plugin/azure/storage/adls/ChecksumTest.java
+++ b/src/test/java/io/kestra/plugin/azure/storage/adls/ChecksumTest.java
@@ -103,6 +103,43 @@ class ChecksumTest extends AbstractTest {
     }
 
     @Test
+    void uploadValidateChecksumStoresHashMatchingLocal() throws Exception {
+        String prefix = IdUtils.create();
+        Upload.Output upload = upload("adls/azure/" + prefix, true);
+
+        Read read = Read.builder()
+            .id(ChecksumTest.class.getSimpleName())
+            .type(Read.class.getName())
+            .endpoint(Property.ofValue(this.adlsEndpoint))
+            .connectionString(Property.ofValue(connectionString))
+            .fileSystem(Property.ofValue(this.fileSystem))
+            .filePath(Property.ofValue(upload.getFile().getName()))
+            .expectedChecksum(Property.ofValue(md5OfApplicationYml()))
+            .build();
+
+        Read.Output run = read.run(runContext(read));
+        assertThat(run.getFile().getUri(), is(notNullValue()));
+    }
+
+    @Test
+    void uploadValidateChecksumRoundTripsCleanly() throws Exception {
+        String prefix = IdUtils.create();
+        Upload.Output upload = upload("adls/azure/" + prefix, true);
+
+        Read read = Read.builder()
+            .id(ChecksumTest.class.getSimpleName())
+            .type(Read.class.getName())
+            .endpoint(Property.ofValue(this.adlsEndpoint))
+            .connectionString(Property.ofValue(connectionString))
+            .fileSystem(Property.ofValue(this.fileSystem))
+            .filePath(Property.ofValue(upload.getFile().getName()))
+            .validateChecksum(Property.ofValue(true))
+            .build();
+
+        assertDoesNotThrow(() -> read.run(runContext(read)));
+    }
+
+    @Test
     void readsStrictMissingChecksumFails() throws Exception {
         String prefix = IdUtils.create();
         upload("adls/azure/" + prefix);

--- a/src/test/java/io/kestra/plugin/azure/storage/blob/AbstractTest.java
+++ b/src/test/java/io/kestra/plugin/azure/storage/blob/AbstractTest.java
@@ -13,6 +13,10 @@ abstract class AbstractTest extends BaseTest {
     private java.util.List<String> directoryToClean = new ArrayList<>();
 
     protected Upload.Output upload(String dir) throws Exception {
+        return upload(dir, false);
+    }
+
+    protected Upload.Output upload(String dir, boolean validateChecksum) throws Exception {
         URI source = upload();
 
         String out = IdUtils.create();
@@ -25,6 +29,7 @@ abstract class AbstractTest extends BaseTest {
             .container(Property.ofValue(this.container))
             .from(Property.ofValue(source.toString()))
             .name(Property.ofValue(dir + "/" + out + ".yml"))
+            .validateChecksum(Property.ofValue(validateChecksum))
             .build();
 
         directoryToClean.add(dir);

--- a/src/test/java/io/kestra/plugin/azure/storage/blob/ChecksumTest.java
+++ b/src/test/java/io/kestra/plugin/azure/storage/blob/ChecksumTest.java
@@ -127,6 +127,26 @@ class ChecksumTest extends AbstractTest {
         assertThat(run.getOutputFiles().size(), is(2));
     }
 
+
+    @Test
+    void uploadValidateChecksumStoresHashMatchingLocal() throws Exception {
+        String prefix = IdUtils.create();
+        Upload.Output upload = upload("tasks/azure/" + prefix, true);
+
+        Download download = Download.builder()
+            .id(ChecksumTest.class.getSimpleName())
+            .type(Download.class.getName())
+            .endpoint(Property.ofValue(this.storageEndpoint))
+            .connectionString(Property.ofValue(connectionString))
+            .container(Property.ofValue(this.container))
+            .name(Property.ofValue(upload.getBlob().getName()))
+            .expectedChecksum(Property.ofValue(md5OfApplicationYml()))
+            .build();
+
+        Download.Output run = download.run(runContext(download));
+        assertThat(run.getBlob().getUri(), is(notNullValue()));
+    }
+
     @Test
     void downloadsStrictMissingChecksumFails() throws Exception {
         String prefix = IdUtils.create();


### PR DESCRIPTION
relates to https://github.com/kestra-io/kestra-ee/issues/5699

### QA

Flow used :

``` yaml
id: azure_storage_blob_download
namespace: company.team

inputs:
  - id: myfile
    type: FILE

tasks:
  - id: upload
    type: io.kestra.plugin.azure.storage.blob.Upload
    endpoint: https://kestra.blob.core.windows.net
    connectionString: "DefaultEndpointsProtocol=https;AccounTRUNCATED
    container: storage
    from: "{{ inputs.myfile }}"
    name: "file.txt"
    validateChecksum: true
```

As checksum is computed on server side, I didn't managed to do some error case.
