### PR TITLE
fix(core): migrate FileSerde to InputStream/OutputStream API for binary ION support

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,3 @@
 version=2.5.1-SNAPSHOT
-kestraVersion=1.3.13
+kestraVersion=1.3.19
 org.gradle.jvmargs=-Xmx4g -XX:MaxMetaspaceSize=1g

--- a/src/main/java/io/kestra/plugin/azure/eventhubs/Produce.java
+++ b/src/main/java/io/kestra/plugin/azure/eventhubs/Produce.java
@@ -11,6 +11,7 @@ import io.kestra.core.exceptions.IllegalVariableEvaluationException;
 import io.kestra.core.models.annotations.Example;
 import io.kestra.core.models.annotations.Metric;
 import io.kestra.core.models.annotations.Plugin;
+import io.kestra.core.models.annotations.PluginProperty;
 import io.kestra.core.models.executions.metrics.Counter;
 import io.kestra.core.models.property.Data;
 import io.kestra.core.models.property.Property;
@@ -29,7 +30,6 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
 import lombok.*;
 import lombok.experimental.SuperBuilder;
-import io.kestra.core.models.annotations.PluginProperty;
 
 /**
  * The {@link RunnableTask} can be used for producing batches of events to Azure Event Hubs.
@@ -192,7 +192,7 @@ public class Produce extends AbstractEventHubTask implements RunnableTask<Produc
     private Output send(final RunContext runContext,
         final EventHubProducerService service,
         final InputStream is) throws IllegalVariableEvaluationException {
-        try (BufferedReader reader = new BufferedReader(new InputStreamReader(is))) {
+        try (BufferedInputStream reader = new BufferedInputStream(is, FileSerde.BUFFER_SIZE)) {
             // Sends
             ProducerContext options = new ProducerContext(
                 runContext.render(getBodyContentType()).as(String.class).orElse(null),

--- a/src/main/java/io/kestra/plugin/azure/eventhubs/service/producer/EventHubProducerService.java
+++ b/src/main/java/io/kestra/plugin/azure/eventhubs/service/producer/EventHubProducerService.java
@@ -1,7 +1,7 @@
 package io.kestra.plugin.azure.eventhubs.service.producer;
 
-import java.io.BufferedReader;
 import java.io.IOException;
+import java.io.InputStream;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -58,7 +58,7 @@ public class EventHubProducerService {
      * @param eventStream The stream of events to send.
      * @return The sender result.
      */
-    public Result sendEvents(BufferedReader eventStream, ProducerContext context) throws IllegalVariableEvaluationException, IOException {
+    public Result sendEvents(InputStream eventStream, ProducerContext context) throws IllegalVariableEvaluationException, IOException {
         Flux<EventDataObject> flowable = FileSerde.readAll(eventStream, EventDataObject.class);
         try (EventHubProducerAsyncClient producer = clientFactory.createAsyncProducerClient(config)) {
             return sendEvents(producer, adapter, flowable, context);

--- a/src/main/java/io/kestra/plugin/azure/storage/table/List.java
+++ b/src/main/java/io/kestra/plugin/azure/storage/table/List.java
@@ -1,8 +1,8 @@
 package io.kestra.plugin.azure.storage.table;
 
-import java.io.BufferedWriter;
+import java.io.BufferedOutputStream;
 import java.io.File;
-import java.io.FileWriter;
+import java.io.FileOutputStream;
 import java.net.URI;
 
 import com.azure.data.tables.TableClient;
@@ -11,6 +11,7 @@ import com.azure.data.tables.models.ListEntitiesOptions;
 import io.kestra.core.models.annotations.Example;
 import io.kestra.core.models.annotations.Metric;
 import io.kestra.core.models.annotations.Plugin;
+import io.kestra.core.models.annotations.PluginProperty;
 import io.kestra.core.models.executions.metrics.Counter;
 import io.kestra.core.models.property.Property;
 import io.kestra.core.models.tasks.RunnableTask;
@@ -24,7 +25,6 @@ import lombok.*;
 import lombok.experimental.SuperBuilder;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
-import io.kestra.core.models.annotations.PluginProperty;
 
 @SuperBuilder
 @ToString
@@ -105,7 +105,7 @@ public class List extends AbstractTableStorage implements RunnableTask<List.Outp
         }
 
         File tempFile = runContext.workingDir().createTempFile(".ion").toFile();
-        try (var output = new BufferedWriter(new FileWriter(tempFile))) {
+        try (var output = new BufferedOutputStream(new FileOutputStream(tempFile))) {
             var flux = Flux.fromIterable(tableClient.listEntities(options, null, null)).map(Entity::to);
 
             Integer rMaxFiles = runContext.render(this.maxFiles).as(Integer.class).orElse(25);

--- a/src/test/java/io/kestra/plugin/azure/datafactory/UploadRunTest.java
+++ b/src/test/java/io/kestra/plugin/azure/datafactory/UploadRunTest.java
@@ -1,7 +1,7 @@
 package io.kestra.plugin.azure.datafactory;
 
-import java.io.BufferedReader;
-import java.io.InputStreamReader;
+import java.io.BufferedInputStream;
+import java.io.InputStream;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
@@ -75,9 +75,9 @@ class UploadRunTest {
         CreateRun.Output output = createRun.run(runContext);
 
         //Get logs and outputs
-        BufferedReader searchInputStream = new BufferedReader(new InputStreamReader(storageInterface.get(TenantService.MAIN_TENANT, null, output.getUri())));
+        InputStream searchInputStream = new BufferedInputStream(storageInterface.get(TenantService.MAIN_TENANT, null, output.getUri()));
         List<Map<String, Object>> results = new ArrayList<>();
-        FileSerde.reader(searchInputStream, r -> results.add((Map<String, Object>) r));
+        FileSerde.read(searchInputStream, r -> results.add((Map<String, Object>) r));
 
         Map<String, Object> logs = results.getLast();
         assertThat(logs.get("status"), is("Succeeded"));
@@ -114,9 +114,9 @@ class UploadRunTest {
         CreateRun.Output output = createRun.run(runContext);
 
         //Get logs and outputs
-        BufferedReader searchInputStream = new BufferedReader(new InputStreamReader(storageInterface.get(TenantService.MAIN_TENANT, null, output.getUri())));
+        InputStream searchInputStream = new BufferedInputStream(storageInterface.get(TenantService.MAIN_TENANT, null, output.getUri()));
         List<Map<String, Object>> results = new ArrayList<>();
-        FileSerde.reader(searchInputStream, r -> results.add((Map<String, Object>) r));
+        FileSerde.read(searchInputStream, r -> results.add((Map<String, Object>) r));
 
         Map<String, Object> logs = results.getLast();
         assertThat(logs.get("status"), is("Succeeded"));

--- a/src/test/java/io/kestra/plugin/azure/eventhubs/service/producer/EventHubProducerServiceTest.java
+++ b/src/test/java/io/kestra/plugin/azure/eventhubs/service/producer/EventHubProducerServiceTest.java
@@ -1,10 +1,10 @@
 package io.kestra.plugin.azure.eventhubs.service.producer;
 
-import java.io.BufferedReader;
+import java.io.BufferedInputStream;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
-import java.io.InputStreamReader;
+import java.io.InputStream;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
@@ -70,7 +70,7 @@ class EventHubProducerServiceTest {
         byte[] data = getDataAsBytesFor(events);
 
         // WHEN
-        try (BufferedReader stream = new BufferedReader(new InputStreamReader(new ByteArrayInputStream(data)))) {
+        try (InputStream stream = new BufferedInputStream(new ByteArrayInputStream(data))) {
             ProducerContext options = new ProducerContext(
                 null, null, maxRecordPerBatch, LOG
             );
@@ -88,7 +88,7 @@ class EventHubProducerServiceTest {
         byte[] data = getDataAsBytesFor(events);
 
         // WHEN
-        try (BufferedReader stream = new BufferedReader(new InputStreamReader(new ByteArrayInputStream(data)))) {
+        try (InputStream stream = new BufferedInputStream(new ByteArrayInputStream(data))) {
 
             ProducerContext options = new ProducerContext(
                 null, null, maxRecordPerBatch, LOG
@@ -116,7 +116,7 @@ class EventHubProducerServiceTest {
         byte[] data = getDataAsBytesFor(events);
 
         // WHEN
-        try (BufferedReader stream = new BufferedReader(new InputStreamReader(new ByteArrayInputStream(data)))) {
+        try (InputStream stream = new BufferedInputStream(new ByteArrayInputStream(data))) {
 
             ProducerContext options = new ProducerContext(
                 null, null, maxRecordPerBatch, LOG

--- a/src/test/java/io/kestra/plugin/azure/storage/table/SuiteTest.java
+++ b/src/test/java/io/kestra/plugin/azure/storage/table/SuiteTest.java
@@ -126,9 +126,9 @@ class SuiteTest {
 
         List.Output listOutput = list.run(runContext);
 
-        BufferedReader inputStream = new BufferedReader(new InputStreamReader(storageInterface.get(TenantService.MAIN_TENANT, null, listOutput.getUri())));
+        InputStream inputStream = new BufferedInputStream(storageInterface.get(TenantService.MAIN_TENANT, null, listOutput.getUri()));
         java.util.List<Map<String, Object>> result = new ArrayList<>();
-        FileSerde.reader(inputStream, r -> result.add((Map<String, Object>) r));
+        FileSerde.read(inputStream, r -> result.add((Map<String, Object>) r));
 
         assertThat(listOutput.getCount(), is(50L));
         assertThat(result.size(), is(50));


### PR DESCRIPTION
Migrate deprecated Reader/Writer-based FileSerde API to InputStream/OutputStream for binary ION compatibility (kestra/kestra#3155).

## Changes
- Bump `kestraVersion` to `1.3.19`
- `EventHubProducerService`: `BufferedReader` parameter → `InputStream`
- `Produce`: `BufferedReader(InputStreamReader(...))` → `BufferedInputStream(...)`
- `List` (storage/table): `BufferedWriter(FileWriter(...))` → `BufferedOutputStream(FileOutputStream(...))`
- Test files: same Reader→InputStream migration, `FileSerde.reader()` → `FileSerde.read()`

**Note:** `CreateRun` retains `BufferedWriter`/`FileWriter` because it uses `FileSerde.writeAll(ObjectMapper, Writer, Flux)` with a custom ION ObjectMapper — no OutputStream overload exists for that signature.