### PR TITLE
fix(security): remediate OWASP/CWE audit findings (2026-06-30)

### DIFF
--- a/src/main/java/io/kestra/plugin/azure/eventhubs/RealtimeTrigger.java
+++ b/src/main/java/io/kestra/plugin/azure/eventhubs/RealtimeTrigger.java
@@ -114,12 +114,15 @@ import io.kestra.core.models.annotations.PluginProperty;
 public class RealtimeTrigger extends AbstractTrigger implements EventHubConsumerInterface, RealtimeTriggerInterface, TriggerOutput<EventDataOutput> {
 
     // TASK'S PARAMETERS
+    @PluginProperty(group = "connection", secret = true)
     protected Property<String> connectionString;
 
     protected Property<String> sharedKeyAccountName;
 
+    @PluginProperty(group = "connection", secret = true)
     protected Property<String> sharedKeyAccountAccessKey;
 
+    @PluginProperty(group = "connection", secret = true)
     protected Property<String> sasToken;
 
     @Builder.Default

--- a/src/main/java/io/kestra/plugin/azure/eventhubs/Trigger.java
+++ b/src/main/java/io/kestra/plugin/azure/eventhubs/Trigger.java
@@ -73,12 +73,15 @@ public class Trigger extends AbstractTrigger implements EventHubConsumerInterfac
     private Duration interval = Duration.ofSeconds(60);
 
     // TASK'S PARAMETERS
+    @PluginProperty(group = "connection", secret = true)
     protected Property<String> connectionString;
 
     protected Property<String> sharedKeyAccountName;
 
+    @PluginProperty(group = "connection", secret = true)
     protected Property<String> sharedKeyAccountAccessKey;
 
+    @PluginProperty(group = "connection", secret = true)
     protected Property<String> sasToken;
 
     @Builder.Default

--- a/src/main/java/io/kestra/plugin/azure/storage/abstracts/AbstractStorage.java
+++ b/src/main/java/io/kestra/plugin/azure/storage/abstracts/AbstractStorage.java
@@ -1,5 +1,6 @@
 package io.kestra.plugin.azure.storage.abstracts;
 
+import io.kestra.core.models.annotations.PluginProperty;
 import io.kestra.core.models.property.Property;
 import io.kestra.plugin.azure.shared.AbstractConnection;
 import io.kestra.plugin.azure.shared.AzureClientInterface;
@@ -16,9 +17,11 @@ import lombok.experimental.SuperBuilder;
 @Getter
 @NoArgsConstructor
 public abstract class AbstractStorage extends AbstractConnection implements AzureClientInterface {
+    @PluginProperty(group = "connection", secret = true)
     protected Property<String> connectionString;
 
     protected Property<String> sharedKeyAccountName;
 
+    @PluginProperty(group = "connection", secret = true)
     protected Property<String> sharedKeyAccountAccessKey;
 }

--- a/src/main/java/io/kestra/plugin/azure/storage/adls/Trigger.java
+++ b/src/main/java/io/kestra/plugin/azure/storage/adls/Trigger.java
@@ -82,12 +82,15 @@ public class Trigger extends AbstractTrigger
 
     protected Property<String> endpoint;
 
+    @PluginProperty(group = "connection", secret = true)
     protected Property<String> connectionString;
 
     protected Property<String> sharedKeyAccountName;
 
+    @PluginProperty(group = "connection", secret = true)
     protected Property<String> sharedKeyAccountAccessKey;
 
+    @PluginProperty(group = "connection", secret = true)
     protected Property<String> sasToken;
 
     @Schema(title = "The ADLS file system (container) to monitor")

--- a/src/main/java/io/kestra/plugin/azure/storage/blob/Trigger.java
+++ b/src/main/java/io/kestra/plugin/azure/storage/blob/Trigger.java
@@ -10,6 +10,7 @@ import com.fasterxml.jackson.annotation.JsonUnwrapped;
 
 import io.kestra.core.models.annotations.Example;
 import io.kestra.core.models.annotations.Plugin;
+import io.kestra.core.models.annotations.PluginProperty;
 import io.kestra.core.models.conditions.ConditionContext;
 import io.kestra.core.models.executions.Execution;
 import io.kestra.core.models.property.Property;
@@ -130,12 +131,15 @@ public class Trigger extends AbstractTrigger implements PollingTriggerInterface,
 
     protected Property<String> endpoint;
 
+    @PluginProperty(group = "connection", secret = true)
     protected Property<String> connectionString;
 
     protected Property<String> sharedKeyAccountName;
 
+    @PluginProperty(group = "connection", secret = true)
     protected Property<String> sharedKeyAccountAccessKey;
 
+    @PluginProperty(group = "connection", secret = true)
     protected Property<String> sasToken;
 
     private Property<String> container;


### PR DESCRIPTION
## Summary

Remediates all findings from the 2026-06-30 automated security audit against OWASP Top 10 (2025), CWE Top 25, and OWASP ASVS Level 1.

## Findings Fixed

- **HIGH** clientSecret field missing @PluginProperty(secret=true) in monitoring Trigger (`src/main/java/io/kestra/plugin/azure/monitoring/Trigger.java:103`)
  - Fix: Verified that `@PluginProperty(secret = true, group = "connection")` is already present on the `clientSecret` field; no code change needed for this finding.

- **HIGH** connectionString, sharedKeyAccountAccessKey and sasToken fields missing secret=true in eventhubs triggers (`src/main/java/io/kestra/plugin/azure/eventhubs/RealtimeTrigger.java:117`)
  - Fix: Added `@PluginProperty(group = "connection", secret = true)` to `connectionString`, `sharedKeyAccountAccessKey`, and `sasToken` in both `eventhubs/RealtimeTrigger.java` and `eventhubs/Trigger.java`.

- **HIGH** connectionString and sharedKeyAccountAccessKey missing secret=true in AbstractStorage base class (`src/main/java/io/kestra/plugin/azure/storage/abstracts/AbstractStorage.java:19`)
  - Fix: Added `@PluginProperty(group = "connection", secret = true)` to `connectionString` and `sharedKeyAccountAccessKey` in `AbstractStorage.java`, and added the same annotations plus `sasToken` secret annotation in `storage/blob/Trigger.java` and `storage/adls/Trigger.java`.

## Testing

- [ ] `./gradlew build` passes
- [ ] No regressions in existing tests
- [ ] Manually verified the patched code paths

## References

- Security Audit EPIC: https://github.com/kestra-io/plugin-azure/issues/309
- [Org-wide Security Meta-EPIC](https://github.com/kestra-io/kestra-ee/issues/9092)

---
*Automated security fix — please review each change carefully before merging.*
